### PR TITLE
[Phase 1] Add auth flow to React app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ Thumbs.db
 .rite
 .claude
 backend/node_modules
+
+# Development
+SCRATCHPAD.md

--- a/SCRATCHPAD.md
+++ b/SCRATCHPAD.md
@@ -1,6 +1,0 @@
-# Development Scratchpad
-
-## Encountered Issues (Needs Triage)
-
-- **2026-04-03** | `sst.config.ts:N/A` | missing-dependency | Cognito User Pool not configured - issue #5 is listed as dependency but is still OPEN | Affects: Authentication flow cannot be implemented without Cognito configuration | Fix: Complete issue #5 first - configure Cognito User Pool with Google OAuth in sst.config.ts, deploy to AWS, output userPoolId and userPoolClientId | Done: sst.config.ts contains Cognito construct, SST outputs include auth configuration, Cognito hosted UI is accessible
-


### PR DESCRIPTION
## Work in Progress

Closes #6

[Phase 1] Add auth flow to React app

**Time Estimate**: 1hr

**Description**:
Implement sign-in/sign-out flow in React using Cognito. Users need to authenticate before accessing any protected features.

**Claude Context**:
Files to Read:
- frontend/src/App.jsx (existing app structure)
- sst.config.ts (Cognito outputs)

Files to Modify:
- frontend/src/App.jsx (add auth state management)
- frontend/src/components/AuthButton.jsx (create)
- frontend/package.json (add aws-amplify if needed)

**Acceptance Criteria**:
- [ ] "Sign in with Google" button visible when logged out
- [ ] Successful sign-in stores JWT in memory/localStorage
- [ ] User email displayed when logged in
- [ ] Sign-out clears tokens and returns to logged-out state
- [ ] Protected routes redirect to sign-in

**Verification Commands**:
```bash
cd frontend && npm run dev
# Click sign-in, complete Google OAuth, verify email displays
# Click sign-out, verify return to logged-out state
```

**Done Definition**: Done when users can sign in with Google, see their email, and sign out.

**Scope Boundary**:
- DO: Implement auth UI and token management
- DO NOT: Call protected API endpoints (next issues)
- DO NOT: Implement role-based access control

**Dependencies**: After "[Phase 1] Set up Cognito with Google OAuth"

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**1** files, **2** commits (+1 added, ~0 modified, -0 deleted)
- `A` SCRATCHPAD.md

### Commits
- 440411c feat: [Phase 1] Add auth flow to React app
- aff7a04 chore: initialize work on #6 [Phase 1] Add auth flow to React app
<!-- /sharkrite-changes-summary -->