### PR TITLE
[Phase 1] Implement GET config endpoint

### DIFF
--- a/backend/functions/config.py
+++ b/backend/functions/config.py
@@ -31,6 +31,14 @@ def handler(event, context):
         # Extract HTTP method (supports both API Gateway v1 and v2 formats)
         http_method = event.get('requestContext', {}).get('http', {}).get('method') or event.get('httpMethod', 'GET')
 
+        # Handle CORS preflight requests before auth check
+        if http_method == 'OPTIONS':
+            return {
+                'statusCode': 200,
+                'headers': headers,
+                'body': ''
+            }
+
         # Extract userId from JWT claims
         # TODO: Once Cognito is set up in Phase 1, this will come from:
         # event['requestContext']['authorizer']['jwt']['claims']['sub']
@@ -56,14 +64,7 @@ def handler(event, context):
             }
 
         # Route to appropriate handler
-        if http_method == 'OPTIONS':
-            # Handle CORS preflight requests
-            return {
-                'statusCode': 200,
-                'headers': headers,
-                'body': ''
-            }
-        elif http_method == 'GET':
+        if http_method == 'GET':
             return handle_get(user_id, headers)
         elif http_method == 'POST':
             return handle_post(user_id, event, headers)
@@ -87,16 +88,16 @@ def handler(event, context):
 def handle_get(user_id, headers):
     """
     Handle GET /api/config - retrieve user profile.
+
+    Returns existing profile if found in DynamoDB, otherwise returns default profile
+    with sensible defaults for new users.
     """
     try:
         user = get_user(user_id)
 
         if not user:
-            return {
-                'statusCode': 404,
-                'headers': headers,
-                'body': json.dumps({'error': 'User profile not found'})
-            }
+            # Return default profile for new users (not yet saved to DB)
+            user = get_default_profile(user_id)
 
         return {
             'statusCode': 200,
@@ -219,6 +220,45 @@ def validate_profile_fields(data):
         return 'Rate must be a valid number'
 
     return None
+
+
+def get_default_profile(user_id):
+    """
+    Generate default profile for new users.
+
+    Returns a profile structure with sensible defaults matching the Users table schema.
+    This profile is NOT saved to DynamoDB — it's returned on first GET and the user
+    must POST to save their actual profile data.
+    """
+    return {
+        'userId': user_id,
+        'email': '',
+        'name': '',
+        'address': '',
+        'personalEmail': '',
+        'rate': 0,
+        'occupation': 'other',
+        'accent': '#b76e79',
+        'template': 'morning-light',
+        'invoiceNote': '',
+        'signatureFont': 'Dancing Script',
+        'accountantEmail': '',
+        'invoiceNumberConfig': {
+            'prefix': 'INV',
+            'includeYear': False,
+            'separator': '-',
+            'padding': 3,
+            'nextNum': 1
+        },
+        'paymentTerms': 'receipt',
+        'taxEnabled': False,
+        'taxRate': 0,
+        'taxLabel': 'Sales Tax',
+        'logoKey': '',
+        'logoSize': 'medium',
+        'clients': [],
+        'activeClientId': ''
+    }
 
 
 def _extract_user_id_from_token(event):

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -1,0 +1,2 @@
+pytest>=8.0
+pytest-cov>=4.0

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -1,0 +1,343 @@
+import json
+import sys
+import os
+import pytest
+from unittest.mock import patch, MagicMock
+
+# Add parent directory to path for imports
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from functions.config import handler, get_default_profile, validate_profile_fields
+from botocore.exceptions import ClientError
+
+
+class TestGetConfig:
+    """Tests for GET /api/config endpoint"""
+
+    def test_get_existing_user_returns_profile(self):
+        """GET with valid JWT and existing user should return user profile"""
+        # Mock event with valid Cognito JWT claims
+        event = {
+            'requestContext': {
+                'http': {'method': 'GET'},
+                'authorizer': {
+                    'jwt': {
+                        'claims': {'sub': 'user-123'}
+                    }
+                }
+            },
+            'headers': {'Authorization': 'Bearer valid-token'}
+        }
+
+        # Mock existing user data
+        mock_user = {
+            'userId': 'user-123',
+            'name': 'Test User',
+            'email': 'test@example.com',
+            'rate': 25.0
+        }
+
+        with patch('functions.config.get_user', return_value=mock_user):
+            response = handler(event, {})
+
+        assert response['statusCode'] == 200
+        body = json.loads(response['body'])
+        assert body['userId'] == 'user-123'
+        assert body['name'] == 'Test User'
+        assert body['email'] == 'test@example.com'
+
+    def test_get_new_user_returns_default_profile(self):
+        """GET with valid JWT and new user should return default profile"""
+        event = {
+            'requestContext': {
+                'http': {'method': 'GET'},
+                'authorizer': {
+                    'jwt': {
+                        'claims': {'sub': 'new-user-456'}
+                    }
+                }
+            },
+            'headers': {'Authorization': 'Bearer valid-token'}
+        }
+
+        # Mock user not found in DB
+        with patch('functions.config.get_user', return_value=None):
+            response = handler(event, {})
+
+        assert response['statusCode'] == 200
+        body = json.loads(response['body'])
+        assert body['userId'] == 'new-user-456'
+        assert body['name'] == ''
+        assert body['email'] == ''
+        assert body['rate'] == 0
+        assert body['template'] == 'morning-light'
+        assert body['clients'] == []
+
+    def test_get_without_auth_header_returns_401(self):
+        """GET without Authorization header should return 401"""
+        event = {
+            'requestContext': {'http': {'method': 'GET'}},
+            'headers': {}
+        }
+
+        response = handler(event, {})
+
+        assert response['statusCode'] == 401
+        body = json.loads(response['body'])
+        assert 'error' in body
+        assert 'Missing Authorization header' in body['error']
+
+    def test_get_with_invalid_jwt_returns_401(self):
+        """GET with invalid JWT (no claims) should return 401"""
+        event = {
+            'requestContext': {
+                'http': {'method': 'GET'},
+                'authorizer': {}  # No JWT claims
+            },
+            'headers': {'Authorization': 'Bearer invalid-token'}
+        }
+
+        response = handler(event, {})
+
+        assert response['statusCode'] == 401
+        body = json.loads(response['body'])
+        assert 'error' in body
+
+    def test_get_handles_dynamodb_error(self):
+        """GET should return 500 when DynamoDB operation fails"""
+        event = {
+            'requestContext': {
+                'http': {'method': 'GET'},
+                'authorizer': {
+                    'jwt': {
+                        'claims': {'sub': 'user-123'}
+                    }
+                }
+            },
+            'headers': {'Authorization': 'Bearer valid-token'}
+        }
+
+        # Mock DynamoDB error
+        mock_error = ClientError(
+            {'Error': {'Code': 'ServiceUnavailable', 'Message': 'Service unavailable'}},
+            'GetItem'
+        )
+
+        with patch('functions.config.get_user', side_effect=mock_error):
+            response = handler(event, {})
+
+        assert response['statusCode'] == 500
+        body = json.loads(response['body'])
+        assert 'error' in body
+
+
+class TestPostConfig:
+    """Tests for POST /api/config endpoint"""
+
+    def test_post_valid_profile_updates_user(self):
+        """POST with valid profile data should update user in DB"""
+        event = {
+            'requestContext': {
+                'http': {'method': 'POST'},
+                'authorizer': {
+                    'jwt': {
+                        'claims': {'sub': 'user-123'}
+                    }
+                }
+            },
+            'headers': {'Authorization': 'Bearer valid-token'},
+            'body': json.dumps({
+                'name': 'Updated User',
+                'email': 'updated@example.com',
+                'rate': 30.0,
+                'address': '123 Main St'
+            })
+        }
+
+        mock_updated = {
+            'userId': 'user-123',
+            'name': 'Updated User',
+            'email': 'updated@example.com',
+            'rate': 30.0,
+            'address': '123 Main St'
+        }
+
+        with patch('functions.config.put_user', return_value=mock_updated):
+            response = handler(event, {})
+
+        assert response['statusCode'] == 200
+        body = json.loads(response['body'])
+        assert body['name'] == 'Updated User'
+        assert body['rate'] == 30.0
+
+    def test_post_missing_required_fields_returns_400(self):
+        """POST without required fields should return 400"""
+        event = {
+            'requestContext': {
+                'http': {'method': 'POST'},
+                'authorizer': {
+                    'jwt': {
+                        'claims': {'sub': 'user-123'}
+                    }
+                }
+            },
+            'headers': {'Authorization': 'Bearer valid-token'},
+            'body': json.dumps({
+                'address': '123 Main St'
+                # Missing name, email, rate
+            })
+        }
+
+        response = handler(event, {})
+
+        assert response['statusCode'] == 400
+        body = json.loads(response['body'])
+        assert 'error' in body
+
+    def test_post_invalid_email_returns_400(self):
+        """POST with invalid email format should return 400"""
+        event = {
+            'requestContext': {
+                'http': {'method': 'POST'},
+                'authorizer': {
+                    'jwt': {
+                        'claims': {'sub': 'user-123'}
+                    }
+                }
+            },
+            'headers': {'Authorization': 'Bearer valid-token'},
+            'body': json.dumps({
+                'name': 'Test User',
+                'email': 'not-an-email',
+                'rate': 25.0
+            })
+        }
+
+        response = handler(event, {})
+
+        assert response['statusCode'] == 400
+        body = json.loads(response['body'])
+        assert 'email' in body['error'].lower()
+
+    def test_post_without_auth_returns_401(self):
+        """POST without Authorization header should return 401"""
+        event = {
+            'requestContext': {'http': {'method': 'POST'}},
+            'headers': {},
+            'body': json.dumps({
+                'name': 'Test',
+                'email': 'test@example.com',
+                'rate': 25.0
+            })
+        }
+
+        response = handler(event, {})
+
+        assert response['statusCode'] == 401
+
+
+class TestDefaultProfile:
+    """Tests for default profile generation"""
+
+    def test_default_profile_structure(self):
+        """get_default_profile should return complete profile structure"""
+        profile = get_default_profile('test-user-id')
+
+        # Check required fields
+        assert profile['userId'] == 'test-user-id'
+        assert profile['email'] == ''
+        assert profile['name'] == ''
+        assert profile['rate'] == 0
+        assert profile['template'] == 'morning-light'
+        assert profile['accent'] == '#b76e79'
+
+        # Check invoice number config defaults
+        assert profile['invoiceNumberConfig']['prefix'] == 'INV'
+        assert profile['invoiceNumberConfig']['includeYear'] is False
+        assert profile['invoiceNumberConfig']['padding'] == 3
+        assert profile['invoiceNumberConfig']['nextNum'] == 1
+
+        # Check payment/tax defaults
+        assert profile['paymentTerms'] == 'receipt'
+        assert profile['taxEnabled'] is False
+        assert profile['taxRate'] == 0
+
+        # Check collections
+        assert profile['clients'] == []
+        assert profile['activeClientId'] == ''
+
+
+class TestValidation:
+    """Tests for profile field validation"""
+
+    def test_validate_missing_name(self):
+        """Validation should fail when name is missing"""
+        data = {'email': 'test@example.com', 'rate': 25.0}
+        error = validate_profile_fields(data)
+        assert error is not None
+        assert 'name' in error.lower()
+
+    def test_validate_missing_email(self):
+        """Validation should fail when email is missing"""
+        data = {'name': 'Test User', 'rate': 25.0}
+        error = validate_profile_fields(data)
+        assert error is not None
+        assert 'email' in error.lower()
+
+    def test_validate_missing_rate(self):
+        """Validation should fail when rate is missing"""
+        data = {'name': 'Test User', 'email': 'test@example.com'}
+        error = validate_profile_fields(data)
+        assert error is not None
+        assert 'rate' in error.lower()
+
+    def test_validate_invalid_email_format(self):
+        """Validation should fail for invalid email format"""
+        data = {'name': 'Test User', 'email': 'invalid-email', 'rate': 25.0}
+        error = validate_profile_fields(data)
+        assert error is not None
+        assert 'email' in error.lower()
+
+    def test_validate_negative_rate(self):
+        """Validation should fail for negative rate"""
+        data = {'name': 'Test User', 'email': 'test@example.com', 'rate': -10}
+        error = validate_profile_fields(data)
+        assert error is not None
+        assert 'positive' in error.lower()
+
+    def test_validate_zero_rate(self):
+        """Validation should fail for zero rate"""
+        data = {'name': 'Test User', 'email': 'test@example.com', 'rate': 0}
+        error = validate_profile_fields(data)
+        assert error is not None
+        assert 'positive' in error.lower()
+
+    def test_validate_valid_profile(self):
+        """Validation should pass for valid profile data"""
+        data = {
+            'name': 'Test User',
+            'email': 'test@example.com',
+            'rate': 25.0
+        }
+        error = validate_profile_fields(data)
+        assert error is None
+
+
+class TestCORS:
+    """Tests for CORS handling"""
+
+    def test_options_request_returns_200(self):
+        """OPTIONS preflight request should return 200 with CORS headers"""
+        event = {
+            'requestContext': {
+                'http': {'method': 'OPTIONS'}
+            },
+            'headers': {'Authorization': 'Bearer valid-token'}
+        }
+
+        response = handler(event, {})
+
+        assert response['statusCode'] == 200
+        assert 'Access-Control-Allow-Origin' in response['headers']
+        assert 'Access-Control-Allow-Methods' in response['headers']
+        assert 'Access-Control-Allow-Headers' in response['headers']


### PR DESCRIPTION
## Work in Progress

Closes #9

[Phase 1] Implement GET config endpoint

**Time Estimate**: 45min

**Description**:
Create Lambda handler for GET /api/config that returns user profile from DynamoDB. First protected endpoint using Cognito JWT.

**Claude Context**:
Files to Read:
- backend/services/db_service.py (data access helpers)
- docs/ADR-webapp-migration.md (Users table schema)
- sst.config.ts (API Gateway configuration)

Files to Modify:
- backend/functions/config.py (create)
- sst.config.ts (add route)

**Acceptance Criteria**:
- [ ] GET /api/config requires valid JWT (401 without)
- [ ] Returns user profile JSON for authenticated user
- [ ] Returns empty profile with defaults for new users
- [ ] User ID extracted from Cognito JWT claims
- [ ] Syntax check passes: `python3 -m py_compile backend/functions/config.py`

**Verification Commands**:
```bash
python3 -m py_compile backend/functions/config.py
sst deploy --stage dev
curl -H "Authorization: Bearer <jwt>" $(sst output ApiEndpoint)/api/config
```

**Done Definition**: Done when authenticated requests return user profile JSON.

**Scope Boundary**:
- DO: Implement GET handler with JWT validation
- DO NOT: Implement POST/update (next issue)
- DO NOT: Add logo URL resolution (Phase 4)

**Dependencies**: After "[Phase 1] Implement DynamoDB service helpers"

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**2** files, **2** commits (+0 added, ~2 modified, -0 deleted)
- `M` backend/functions/config.py
- `M` sst.config.ts

### Commits
- f4e8902 chore: [Phase 1] Implement GET config endpoint
- 74d90fd chore: initialize work on #9 [Phase 1] Implement GET config endpoint
<!-- /sharkrite-changes-summary -->