### PR TITLE
[Phase 2] Implement scan-month endpoint

### DIFF
--- a/backend/functions/scan_month.py
+++ b/backend/functions/scan_month.py
@@ -1,13 +1,163 @@
 import json
+import sys
+import os
+
+# Add parent directory to path for imports
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from services.db_service import query_invoices
+from botocore.exceptions import ClientError
 
 
 def handler(event, context):
     """
     Lambda handler for GET /api/scan-month — scan for existing weekly invoices in a given month.
-    TODO: Implement in Phase 2.
+
+    Query parameters:
+        year (required): 4-digit year (e.g., 2026)
+        month (required): month number 1-12
+
+    Returns:
+        200: Array of invoice metadata for the specified month
+        400: Invalid query parameters
+        401: Missing or invalid authorization
+        500: Server error
     """
-    return {
-        'statusCode': 501,
-        'headers': {'Content-Type': 'application/json'},
-        'body': json.dumps({'error': 'Not yet implemented'})
+    # CORS headers for all responses
+    headers = {
+        'Content-Type': 'application/json',
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Methods': 'GET, OPTIONS',
+        'Access-Control-Allow-Headers': 'Content-Type, Authorization',
     }
+
+    try:
+        # Extract HTTP method (supports both API Gateway v1 and v2 formats)
+        http_method = event.get('requestContext', {}).get('http', {}).get('method') or event.get('httpMethod', 'GET')
+
+        # Handle CORS preflight requests before auth check
+        if http_method == 'OPTIONS':
+            return {
+                'statusCode': 200,
+                'headers': headers,
+                'body': ''
+            }
+
+        # Extract userId from JWT claims
+        auth_header = event.get('headers', {}).get('authorization') or event.get('headers', {}).get('Authorization')
+
+        if not auth_header:
+            return {
+                'statusCode': 401,
+                'headers': headers,
+                'body': json.dumps({'error': 'Missing Authorization header'})
+            }
+
+        user_id = _extract_user_id_from_token(event)
+
+        if not user_id:
+            return {
+                'statusCode': 401,
+                'headers': headers,
+                'body': json.dumps({'error': 'Invalid or expired token'})
+            }
+
+        # Extract and validate query parameters
+        query_params = event.get('queryStringParameters') or {}
+        year = query_params.get('year')
+        month = query_params.get('month')
+
+        if not year or not month:
+            return {
+                'statusCode': 400,
+                'headers': headers,
+                'body': json.dumps({'error': 'Both year and month query parameters are required'})
+            }
+
+        # Validate year and month
+        try:
+            year_int = int(year)
+            month_int = int(month)
+
+            if year_int < 1900 or year_int > 2100:
+                return {
+                    'statusCode': 400,
+                    'headers': headers,
+                    'body': json.dumps({'error': 'Year must be between 1900 and 2100'})
+                }
+
+            if month_int < 1 or month_int > 12:
+                return {
+                    'statusCode': 400,
+                    'headers': headers,
+                    'body': json.dumps({'error': 'Month must be between 1 and 12'})
+                }
+        except ValueError:
+            return {
+                'statusCode': 400,
+                'headers': headers,
+                'body': json.dumps({'error': 'Year and month must be valid integers'})
+            }
+
+        # Construct invoiceId range for the month
+        # Format: INV-YYYYMMDD (e.g., INV-20260301 to INV-20260331)
+        # Using day 01-31 covers all possible dates in any month
+        invoice_id_start = f"INV-{year_int:04d}{month_int:02d}01"
+        invoice_id_end = f"INV-{year_int:04d}{month_int:02d}31"
+
+        # Query DynamoDB for invoices in this date range
+        invoices = query_invoices(
+            user_id,
+            filters={
+                'invoiceId_start': invoice_id_start,
+                'invoiceId_end': invoice_id_end,
+                'type': 'weekly'  # Only weekly invoices (exclude monthly reports)
+            }
+        )
+
+        # Return invoice metadata (not full PDF content)
+        return {
+            'statusCode': 200,
+            'headers': headers,
+            'body': json.dumps(invoices)
+        }
+
+    except ClientError as e:
+        print(f"DynamoDB error in GET /api/scan-month: {str(e)}")
+        return {
+            'statusCode': 500,
+            'headers': headers,
+            'body': json.dumps({'error': 'Failed to query invoices'})
+        }
+    except Exception as e:
+        print(f"Unhandled error in scan_month handler: {str(e)}")
+        return {
+            'statusCode': 500,
+            'headers': headers,
+            'body': json.dumps({'error': 'Internal server error'})
+        }
+
+
+def _extract_user_id_from_token(event):
+    """
+    Extract userId from JWT token claims.
+
+    Returns None if no valid JWT claims are present.
+    """
+    # Check for Cognito authorizer claims (API Gateway v2 with JWT authorizer)
+    try:
+        claims = event.get('requestContext', {}).get('authorizer', {}).get('jwt', {}).get('claims', {})
+        if claims and 'sub' in claims:
+            return claims.get('sub')
+    except (KeyError, AttributeError):
+        pass
+
+    # Fallback: check for lambda authorizer format (API Gateway v1)
+    try:
+        authorizer = event.get('requestContext', {}).get('authorizer', {})
+        if authorizer and 'claims' in authorizer and 'sub' in authorizer['claims']:
+            return authorizer['claims'].get('sub')
+    except (KeyError, AttributeError):
+        pass
+
+    return None

--- a/backend/tests/test_scan_month.py
+++ b/backend/tests/test_scan_month.py
@@ -1,0 +1,427 @@
+import json
+import sys
+import os
+import pytest
+from unittest.mock import patch, MagicMock
+
+# Add parent directory to path for imports
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from functions.scan_month import handler
+from botocore.exceptions import ClientError
+
+
+class TestScanMonth:
+    """Tests for GET /api/scan-month endpoint"""
+
+    def test_scan_month_with_invoices_returns_array(self):
+        """GET with valid params should return array of invoices for the month"""
+        event = {
+            'requestContext': {
+                'http': {'method': 'GET'},
+                'authorizer': {
+                    'jwt': {
+                        'claims': {'sub': 'user-123'}
+                    }
+                }
+            },
+            'headers': {'Authorization': 'Bearer valid-token'},
+            'queryStringParameters': {
+                'year': '2026',
+                'month': '3'
+            }
+        }
+
+        # Mock invoices for March 2026
+        mock_invoices = [
+            {
+                'userId': 'user-123',
+                'invoiceId': 'INV-20260303',
+                'type': 'weekly',
+                'totalHours': 40,
+                'totalPay': 1120.00
+            },
+            {
+                'userId': 'user-123',
+                'invoiceId': 'INV-20260310',
+                'type': 'weekly',
+                'totalHours': 38,
+                'totalPay': 1064.00
+            }
+        ]
+
+        with patch('functions.scan_month.query_invoices', return_value=mock_invoices):
+            response = handler(event, {})
+
+        assert response['statusCode'] == 200
+        body = json.loads(response['body'])
+        assert isinstance(body, list)
+        assert len(body) == 2
+        assert body[0]['invoiceId'] == 'INV-20260303'
+        assert body[1]['invoiceId'] == 'INV-20260310'
+
+    def test_scan_month_empty_month_returns_empty_array(self):
+        """GET for month with no invoices should return empty array (not error)"""
+        event = {
+            'requestContext': {
+                'http': {'method': 'GET'},
+                'authorizer': {
+                    'jwt': {
+                        'claims': {'sub': 'user-123'}
+                    }
+                }
+            },
+            'headers': {'Authorization': 'Bearer valid-token'},
+            'queryStringParameters': {
+                'year': '2026',
+                'month': '12'
+            }
+        }
+
+        with patch('functions.scan_month.query_invoices', return_value=[]):
+            response = handler(event, {})
+
+        assert response['statusCode'] == 200
+        body = json.loads(response['body'])
+        assert isinstance(body, list)
+        assert len(body) == 0
+
+    def test_scan_month_queries_correct_date_range(self):
+        """Should construct correct invoiceId range for DynamoDB query"""
+        event = {
+            'requestContext': {
+                'http': {'method': 'GET'},
+                'authorizer': {
+                    'jwt': {
+                        'claims': {'sub': 'user-123'}
+                    }
+                }
+            },
+            'headers': {'Authorization': 'Bearer valid-token'},
+            'queryStringParameters': {
+                'year': '2026',
+                'month': '3'
+            }
+        }
+
+        with patch('functions.scan_month.query_invoices', return_value=[]) as mock_query:
+            handler(event, {})
+
+            # Verify query_invoices was called with correct parameters
+            mock_query.assert_called_once()
+            call_args = mock_query.call_args
+            assert call_args[0][0] == 'user-123'  # userId
+            assert call_args[1]['filters']['invoiceId_start'] == 'INV-20260301'
+            assert call_args[1]['filters']['invoiceId_end'] == 'INV-20260331'
+            assert call_args[1]['filters']['type'] == 'weekly'
+
+    def test_scan_month_filters_weekly_invoices_only(self):
+        """Should filter for type=weekly to exclude monthly reports"""
+        event = {
+            'requestContext': {
+                'http': {'method': 'GET'},
+                'authorizer': {
+                    'jwt': {
+                        'claims': {'sub': 'user-123'}
+                    }
+                }
+            },
+            'headers': {'Authorization': 'Bearer valid-token'},
+            'queryStringParameters': {
+                'year': '2026',
+                'month': '3'
+            }
+        }
+
+        with patch('functions.scan_month.query_invoices', return_value=[]) as mock_query:
+            handler(event, {})
+
+            # Verify type filter is set to weekly
+            filters = mock_query.call_args[1]['filters']
+            assert filters['type'] == 'weekly'
+
+    def test_scan_month_missing_year_returns_400(self):
+        """GET without year parameter should return 400"""
+        event = {
+            'requestContext': {
+                'http': {'method': 'GET'},
+                'authorizer': {
+                    'jwt': {
+                        'claims': {'sub': 'user-123'}
+                    }
+                }
+            },
+            'headers': {'Authorization': 'Bearer valid-token'},
+            'queryStringParameters': {
+                'month': '3'
+            }
+        }
+
+        response = handler(event, {})
+
+        assert response['statusCode'] == 400
+        body = json.loads(response['body'])
+        assert 'error' in body
+        assert 'year and month' in body['error'].lower()
+
+    def test_scan_month_missing_month_returns_400(self):
+        """GET without month parameter should return 400"""
+        event = {
+            'requestContext': {
+                'http': {'method': 'GET'},
+                'authorizer': {
+                    'jwt': {
+                        'claims': {'sub': 'user-123'}
+                    }
+                }
+            },
+            'headers': {'Authorization': 'Bearer valid-token'},
+            'queryStringParameters': {
+                'year': '2026'
+            }
+        }
+
+        response = handler(event, {})
+
+        assert response['statusCode'] == 400
+        body = json.loads(response['body'])
+        assert 'error' in body
+
+    def test_scan_month_invalid_month_returns_400(self):
+        """GET with month outside 1-12 range should return 400"""
+        event = {
+            'requestContext': {
+                'http': {'method': 'GET'},
+                'authorizer': {
+                    'jwt': {
+                        'claims': {'sub': 'user-123'}
+                    }
+                }
+            },
+            'headers': {'Authorization': 'Bearer valid-token'},
+            'queryStringParameters': {
+                'year': '2026',
+                'month': '13'
+            }
+        }
+
+        response = handler(event, {})
+
+        assert response['statusCode'] == 400
+        body = json.loads(response['body'])
+        assert 'error' in body
+        assert 'month' in body['error'].lower()
+
+    def test_scan_month_month_zero_returns_400(self):
+        """GET with month=0 should return 400"""
+        event = {
+            'requestContext': {
+                'http': {'method': 'GET'},
+                'authorizer': {
+                    'jwt': {
+                        'claims': {'sub': 'user-123'}
+                    }
+                }
+            },
+            'headers': {'Authorization': 'Bearer valid-token'},
+            'queryStringParameters': {
+                'year': '2026',
+                'month': '0'
+            }
+        }
+
+        response = handler(event, {})
+
+        assert response['statusCode'] == 400
+        body = json.loads(response['body'])
+        assert 'error' in body
+
+    def test_scan_month_invalid_year_returns_400(self):
+        """GET with year outside valid range should return 400"""
+        event = {
+            'requestContext': {
+                'http': {'method': 'GET'},
+                'authorizer': {
+                    'jwt': {
+                        'claims': {'sub': 'user-123'}
+                    }
+                }
+            },
+            'headers': {'Authorization': 'Bearer valid-token'},
+            'queryStringParameters': {
+                'year': '1800',
+                'month': '3'
+            }
+        }
+
+        response = handler(event, {})
+
+        assert response['statusCode'] == 400
+        body = json.loads(response['body'])
+        assert 'error' in body
+        assert 'year' in body['error'].lower()
+
+    def test_scan_month_non_numeric_year_returns_400(self):
+        """GET with non-numeric year should return 400"""
+        event = {
+            'requestContext': {
+                'http': {'method': 'GET'},
+                'authorizer': {
+                    'jwt': {
+                        'claims': {'sub': 'user-123'}
+                    }
+                }
+            },
+            'headers': {'Authorization': 'Bearer valid-token'},
+            'queryStringParameters': {
+                'year': 'abc',
+                'month': '3'
+            }
+        }
+
+        response = handler(event, {})
+
+        assert response['statusCode'] == 400
+        body = json.loads(response['body'])
+        assert 'error' in body
+        assert 'integer' in body['error'].lower()
+
+    def test_scan_month_without_auth_returns_401(self):
+        """GET without Authorization header should return 401"""
+        event = {
+            'requestContext': {'http': {'method': 'GET'}},
+            'headers': {},
+            'queryStringParameters': {
+                'year': '2026',
+                'month': '3'
+            }
+        }
+
+        response = handler(event, {})
+
+        assert response['statusCode'] == 401
+        body = json.loads(response['body'])
+        assert 'error' in body
+        assert 'Missing Authorization header' in body['error']
+
+    def test_scan_month_with_invalid_jwt_returns_401(self):
+        """GET with invalid JWT (no claims) should return 401"""
+        event = {
+            'requestContext': {
+                'http': {'method': 'GET'},
+                'authorizer': {}  # No JWT claims
+            },
+            'headers': {'Authorization': 'Bearer invalid-token'},
+            'queryStringParameters': {
+                'year': '2026',
+                'month': '3'
+            }
+        }
+
+        response = handler(event, {})
+
+        assert response['statusCode'] == 401
+        body = json.loads(response['body'])
+        assert 'error' in body
+
+    def test_scan_month_handles_dynamodb_error(self):
+        """Should return 500 when DynamoDB operation fails"""
+        event = {
+            'requestContext': {
+                'http': {'method': 'GET'},
+                'authorizer': {
+                    'jwt': {
+                        'claims': {'sub': 'user-123'}
+                    }
+                }
+            },
+            'headers': {'Authorization': 'Bearer valid-token'},
+            'queryStringParameters': {
+                'year': '2026',
+                'month': '3'
+            }
+        }
+
+        # Mock DynamoDB error
+        mock_error = ClientError(
+            {'Error': {'Code': 'ServiceUnavailable', 'Message': 'Service unavailable'}},
+            'Query'
+        )
+
+        with patch('functions.scan_month.query_invoices', side_effect=mock_error):
+            response = handler(event, {})
+
+        assert response['statusCode'] == 500
+        body = json.loads(response['body'])
+        assert 'error' in body
+
+    def test_scan_month_february_uses_day_31(self):
+        """February query should use day 31 (safe to query non-existent dates)"""
+        event = {
+            'requestContext': {
+                'http': {'method': 'GET'},
+                'authorizer': {
+                    'jwt': {
+                        'claims': {'sub': 'user-123'}
+                    }
+                }
+            },
+            'headers': {'Authorization': 'Bearer valid-token'},
+            'queryStringParameters': {
+                'year': '2026',
+                'month': '2'
+            }
+        }
+
+        with patch('functions.scan_month.query_invoices', return_value=[]) as mock_query:
+            handler(event, {})
+
+            # Verify range includes day 31 (catches all dates, safe for DynamoDB BETWEEN)
+            filters = mock_query.call_args[1]['filters']
+            assert filters['invoiceId_start'] == 'INV-20260201'
+            assert filters['invoiceId_end'] == 'INV-20260231'
+
+    def test_scan_month_single_digit_month_zero_padded(self):
+        """Single-digit months should be zero-padded in invoiceId range"""
+        event = {
+            'requestContext': {
+                'http': {'method': 'GET'},
+                'authorizer': {
+                    'jwt': {
+                        'claims': {'sub': 'user-123'}
+                    }
+                }
+            },
+            'headers': {'Authorization': 'Bearer valid-token'},
+            'queryStringParameters': {
+                'year': '2026',
+                'month': '5'
+            }
+        }
+
+        with patch('functions.scan_month.query_invoices', return_value=[]) as mock_query:
+            handler(event, {})
+
+            filters = mock_query.call_args[1]['filters']
+            assert filters['invoiceId_start'] == 'INV-20260501'
+            assert filters['invoiceId_end'] == 'INV-20260531'
+
+
+class TestCORS:
+    """Tests for CORS handling"""
+
+    def test_options_request_returns_200(self):
+        """OPTIONS preflight request should return 200 with CORS headers"""
+        event = {
+            'requestContext': {
+                'http': {'method': 'OPTIONS'}
+            },
+            'headers': {'Authorization': 'Bearer valid-token'}
+        }
+
+        response = handler(event, {})
+
+        assert response['statusCode'] == 200
+        assert 'Access-Control-Allow-Origin' in response['headers']
+        assert 'Access-Control-Allow-Methods' in response['headers']
+        assert 'Access-Control-Allow-Headers' in response['headers']

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -109,6 +109,12 @@ export default $config({
       link: [usersTable],
     });
 
+    // Phase 2: Scan month for existing invoices
+    api.route("GET /api/scan-month", {
+      handler: "backend/functions/scan_month.handler",
+      link: [invoicesTable],
+    });
+
     // Phase 2: Test ReportLab layer (temporary endpoint for validation)
     api.route("GET /api/test-reportlab", {
       handler: "backend/functions/test_reportlab.handler",


### PR DESCRIPTION
## Work in Progress

Closes #17

[Phase 2] Implement scan-month endpoint

**Time Estimate**: 45min

**Description**:
Create GET /api/scan-month endpoint that queries DynamoDB for existing weekly invoices in a given month. Used by monthly report to aggregate data.

**Claude Context**:
Files to Read:
- backend/services/db_service.py (query helpers)
- docs/ADR-webapp-migration.md (scan-month access pattern)

Files to Modify:
- backend/functions/scan_month.py (create)
- sst.config.ts (add route)

**Acceptance Criteria**:
- [ ] GET /api/scan-month?year=2026&month=3 returns invoices for March 2026
- [ ] Query uses userId partition key with invoiceId sort key range
- [ ] Returns array of invoice metadata (not full PDFs)
- [ ] Empty array for months with no invoices
- [ ] Syntax check passes: `python3 -m py_compile backend/functions/scan_month.py`

**Verification Commands**:
```bash
python3 -m py_compile backend/functions/scan_month.py
sst deploy --stage dev
curl -H "Authorization: Bearer <jwt>" "$(sst output ApiEndpoint)/api/scan-month?year=2026&month=3"
```

**Done Definition**: Done when endpoint returns correct invoices for the specified month.

**Scope Boundary**:
- DO: Query DynamoDB with sort key range for month
- DO NOT: Generate monthly report PDF (next issue)

**Dependencies**: After "[Phase 2] Implement weekly invoice submission"

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**3** files, **2** commits (+1 added, ~2 modified, -0 deleted)
- `M` backend/functions/scan_month.py
- `A` backend/tests/test_scan_month.py
- `M` sst.config.ts

### Commits
- bdea649 feat: [Phase 2] Implement scan-month endpoint
- 32685ba chore: initialize work on #17 [Phase 2] Implement scan-month endpoint
<!-- /sharkrite-changes-summary -->

---

## Follow-up Issues

**From assessment on 2026-04-04T00:02:42Z:**
- Created: #75 
- Updated: none