### PR TITLE
[Phase 5] Update UI for industry-agnostic labels

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -258,7 +258,12 @@ const OCC_LABELS = {
 
 function getOccLabels(config) {
   const occ = config.occupation || "";
-  return OCC_LABELS[occ] || OCC_LABELS[""];
+  const labels = OCC_LABELS[occ] || OCC_LABELS[""];
+  // Ensure clientFieldLabel always has a fallback value
+  return {
+    ...labels,
+    clientFieldLabel: labels.clientFieldLabel || "Client",
+  };
 }
 
 // Helper to determine if occupation requires health-specific fields (vitals, medications)
@@ -293,11 +298,14 @@ function getActiveClient(config) {
   const client = active || clients[0] || { id:"", name:"", address:"", objective:"", defaultShift:{start:"09:00",end:"17:00"}, meds:[] };
 
   // Migration: handle legacy patientName/patientAddress fields
-  if (client.patientName && !client.name) {
-    client.name = client.patientName;
-  }
-  if (client.patientAddress && !client.address) {
-    client.address = client.patientAddress;
+  // Return a new object to avoid mutating the shared reference
+  const needsMigration = (client.patientName && !client.name) || (client.patientAddress && !client.address);
+  if (needsMigration) {
+    return {
+      ...client,
+      name: client.name || client.patientName,
+      address: client.address || client.patientAddress,
+    };
   }
 
   return client;


### PR DESCRIPTION
## Work in Progress

Closes #35

[Phase 5] Update UI for industry-agnostic labels

**Time Estimate**: 45min

**Description**:
Pass through all UI text to replace home health–specific language with industry-agnostic terms. Labels adapt based on user's occupation.

**Claude Context**:
Files to Read:
- frontend/src/App.jsx (all UI text)
- docs/ADR-webapp-migration.md (industry-agnostic design section)

Files to Modify:
- frontend/src/App.jsx (text replacements)

**Acceptance Criteria**:
- [ ] "Patient" replaced with occupation-appropriate term (Client/Student/etc.)
- [ ] Invoice label shows "Contractor Invoice" or "Service Invoice"
- [ ] Client field label adapts: Client / Agency / Family based on occupation
- [ ] Log template fields: care-specific only shown for health occupations
- [ ] All hardcoded home health text identified and parameterized

**Verification Commands**:
```bash
cd frontend && npm run dev
# Switch occupation in Profile, verify labels update throughout app
```

**Done Definition**: Done when a tutor sees "Student" not "Patient" throughout the UI.

**Scope Boundary**:
- DO: Update all user-facing text
- DO NOT: Add new occupations to the selector

**Dependencies**: After "[Phase 4] Wire bulk actions in List view"

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**1** files, **2** commits (+0 added, ~1 modified, -0 deleted)
- `M` frontend/src/App.jsx

### Commits
- 61f4351 feat: [Phase 5] Update UI for industry-agnostic labels
- 7f05e6b chore: initialize work on #35 [Phase 5] Update UI for industry-agnostic labels
<!-- /sharkrite-changes-summary -->