### PR TITLE
[Phase 5] Configure custom domain DNS and SSL

### DIFF
--- a/CUSTOM-DOMAIN-VALIDATION.md
+++ b/CUSTOM-DOMAIN-VALIDATION.md
@@ -1,0 +1,129 @@
+# Custom Domain Configuration Validation
+
+## Configuration Summary
+
+This document validates the custom domain configuration for `goinvoi.com`.
+
+## ✅ Configuration Checklist
+
+### 1. API Gateway Custom Domain
+- **Location:** sst.config.ts:100-103
+- **Domain:** api.goinvoi.com
+- **Stage Gating:** Only enabled for production stage
+- **DNS Management:** Route53 (sst.aws.dns())
+- **ACM Certificate:** Auto-created and validated
+
+### 2. CloudFront/StaticSite Custom Domain
+- **Location:** sst.config.ts:288-292
+- **Primary Domain:** goinvoi.com
+- **Aliases:** www.goinvoi.com (redirects to apex)
+- **Stage Gating:** Only enabled for production stage
+- **DNS Management:** Route53 (sst.aws.dns())
+- **ACM Certificate:** Auto-created in us-east-1 (required for CloudFront)
+
+### 3. CORS Configuration
+- **Location:** sst.config.ts:106-108
+- **Production Origins:** 
+  - https://goinvoi.com
+  - https://www.goinvoi.com
+- **Dev Origins:** * (wildcard)
+- **Methods:** GET, POST, PUT, DELETE, OPTIONS
+- **Headers:** Content-Type, Authorization
+
+### 4. Cognito Callback URLs
+- **Location:** sst.config.ts:62-66
+- **Production Callback:** https://goinvoi.com/auth/callback
+- **Production Logout:** https://goinvoi.com/auth/logout
+- **Dev Callback:** http://localhost:5173/auth/callback
+- **Dev Logout:** http://localhost:5173/auth/logout
+
+### 5. SST Outputs
+- **Location:** sst.config.ts:313-314
+- **Custom Domain:** goinvoi.com (production only)
+- **API Domain:** api.goinvoi.com (production only)
+
+## 📋 Acceptance Criteria Status
+
+| Criterion | Status | Notes |
+|-----------|--------|-------|
+| ACM certificate requested for goinvoi.com and www.goinvoi.com | ✅ | Auto-requested on production deploy |
+| Certificate validated via DNS | ⏳ | Will auto-validate after DNS setup |
+| CloudFront distribution configured with custom domain | ✅ | StaticSite configured with domain |
+| DNS records point goinvoi.com to CloudFront | ⏳ | Requires manual DNS setup at registrar |
+| HTTPS works at https://goinvoi.com | ⏳ | Will work after DNS propagation |
+| HTTP redirects to HTTPS | ✅ | CloudFront handles automatically |
+| api.goinvoi.com configured for API Gateway | ✅ | API Gateway custom domain configured |
+
+## 🔧 Next Steps (Manual)
+
+After merging this configuration:
+
+1. **Deploy to production:**
+   ```bash
+   sst deploy --stage production
+   ```
+
+2. **Get Route53 nameservers:**
+   ```bash
+   aws route53 list-hosted-zones | grep -A 5 "goinvoi.com"
+   aws route53 get-hosted-zone --id <HOSTED_ZONE_ID>
+   ```
+
+3. **Update domain registrar:**
+   - Point goinvoi.com nameservers to Route53 nameservers
+   - Wait for DNS propagation (1-48 hours)
+
+4. **Verify setup:**
+   ```bash
+   # Should return 200 with CloudFront headers
+   curl -I https://goinvoi.com
+   
+   # Should return 301 redirect to HTTPS
+   curl -I http://goinvoi.com
+   
+   # Should resolve to API Gateway
+   dig api.goinvoi.com
+   ```
+
+5. **Update Google OAuth:**
+   - Add https://goinvoi.com/auth/callback to authorized redirect URIs
+   - Add https://goinvoi.com/auth/logout to authorized logout URIs
+
+## 🏗️ Architecture
+
+```
+goinvoi.com (CloudFront + S3)
+├── ACM Certificate (auto-created in us-east-1)
+├── DNS (Route53)
+└── Aliases: www.goinvoi.com
+
+api.goinvoi.com (API Gateway)
+├── ACM Certificate (auto-created in deployment region)
+└── DNS (Route53)
+```
+
+## 🔐 Security Features
+
+- ✅ HTTPS enforced (HTTP → HTTPS redirect)
+- ✅ ACM managed certificates (auto-renewal)
+- ✅ CORS restricted to custom domain in production
+- ✅ TLS 1.2+ enforced by CloudFront
+- ✅ Stage-gated configuration (dev uses localhost)
+
+## 📝 Documentation
+
+- **DNS Setup Guide:** DNS-SETUP.md
+- **SST Config:** sst.config.ts
+- **Architecture Decision:** docs/ADR-webapp-migration.md
+
+## 🚨 Important Notes
+
+1. **Stage Gating:** Custom domain only applies to production stage. Dev stage continues to use auto-generated URLs.
+2. **DNS Propagation:** Can take up to 48 hours but usually completes in 1-2 hours.
+3. **Certificate Validation:** Happens automatically once DNS points to Route53.
+4. **No Breaking Changes:** Dev workflow is unaffected; custom domain only used in production.
+5. **Cost:** ~$0.50/month for Route53 hosted zone. ACM certificates are free.
+
+## ✅ Validation Complete
+
+All configuration changes are in place. The infrastructure is ready for production deployment.

--- a/DNS-SETUP.md
+++ b/DNS-SETUP.md
@@ -1,0 +1,172 @@
+# DNS Setup Guide for goinvoi.com
+
+This guide explains how to configure DNS for the custom domain after deploying to production.
+
+## Overview
+
+The SST infrastructure is now configured to use `goinvoi.com` as the custom domain in production. The setup includes:
+
+- **goinvoi.com** - Main site (CloudFront + S3)
+- **www.goinvoi.com** - Redirects to apex domain
+- **api.goinvoi.com** - API Gateway endpoint
+
+## Prerequisites
+
+1. Domain `goinvoi.com` must be registered
+2. Access to domain registrar account (where the domain was purchased)
+3. Production deployment completed: `sst deploy --stage production`
+
+## Step 1: Deploy to Production
+
+```bash
+# Deploy the infrastructure to production stage
+sst deploy --stage production
+```
+
+This will:
+- Create Route53 hosted zone for `goinvoi.com`
+- Request ACM certificates for both the site and API
+- Set up CloudFront distribution
+- Configure API Gateway custom domain
+- Output the Route53 nameservers
+
+## Step 2: Get Route53 Nameservers
+
+After deployment, run:
+
+```bash
+# List the hosted zone
+aws route53 list-hosted-zones | grep -A 5 "goinvoi.com"
+
+# Get the nameservers for your hosted zone (replace HOSTED_ZONE_ID)
+aws route53 get-hosted-zone --id HOSTED_ZONE_ID
+```
+
+You'll get 4 nameservers that look like:
+- ns-1234.awsdns-12.org
+- ns-5678.awsdns-34.com
+- ns-9012.awsdns-56.net
+- ns-3456.awsdns-78.co.uk
+
+## Step 3: Update Domain Registrar
+
+Go to your domain registrar (GoDaddy, Namecheap, Google Domains, etc.) and:
+
+1. Navigate to DNS settings for `goinvoi.com`
+2. Change the nameservers to the 4 Route53 nameservers from Step 2
+3. Save the changes
+
+**Note:** DNS propagation can take up to 48 hours, but usually completes within 1-2 hours.
+
+## Step 4: Verify DNS Configuration
+
+After DNS has propagated, verify the setup:
+
+```bash
+# Check DNS resolution
+dig goinvoi.com
+dig www.goinvoi.com
+dig api.goinvoi.com
+
+# Check HTTPS (should return 200 with CloudFront headers)
+curl -I https://goinvoi.com
+
+# Check HTTP redirect (should redirect to HTTPS)
+curl -I http://goinvoi.com
+```
+
+## Step 5: Verify ACM Certificate
+
+Check that the SSL certificate is active:
+
+```bash
+# List certificates
+aws acm list-certificates --region us-east-1
+
+# Get certificate details (replace CERTIFICATE_ARN)
+aws acm describe-certificate --certificate-arn CERTIFICATE_ARN --region us-east-1
+```
+
+The certificate should show:
+- Status: `ISSUED`
+- Domain: `goinvoi.com` and `www.goinvoi.com`
+- Validation method: `DNS`
+
+## Troubleshooting
+
+### Certificate Pending Validation
+
+If the ACM certificate is stuck in "Pending Validation":
+
+1. Verify nameservers are correctly updated at the registrar
+2. Check DNS propagation: `dig NS goinvoi.com`
+3. Wait for DNS to propagate (can take up to 48 hours)
+4. SST will automatically retry certificate validation
+
+### HTTPS Not Working
+
+1. Ensure DNS has propagated: `dig goinvoi.com`
+2. Check CloudFront distribution status: should be "Deployed"
+3. Check certificate status: should be "Issued"
+4. Clear browser cache and try incognito mode
+5. Wait for CloudFront cache to update (can take 15-20 minutes)
+
+### API Subdomain Not Working
+
+1. Verify `api.goinvoi.com` DNS record exists in Route53
+2. Check API Gateway custom domain configuration
+3. Ensure ACM certificate includes the API subdomain
+4. Test the API directly: `curl https://api.goinvoi.com/hello`
+
+## Expected Results
+
+After DNS configuration is complete:
+
+✅ `https://goinvoi.com` - Loads the React app with valid SSL
+✅ `https://www.goinvoi.com` - Redirects to apex domain
+✅ `http://goinvoi.com` - Redirects to HTTPS
+✅ `https://api.goinvoi.com` - API Gateway responds to requests
+✅ Certificate shows valid for goinvoi.com in browser
+✅ CloudFront headers visible in response
+
+## DNS Records Created by SST
+
+SST automatically creates these Route53 records:
+
+| Type | Name | Purpose |
+|------|------|---------|
+| A | goinvoi.com | Points to CloudFront distribution (IPv4) |
+| AAAA | goinvoi.com | Points to CloudFront distribution (IPv6) |
+| A | www.goinvoi.com | Alias to apex domain |
+| AAAA | www.goinvoi.com | Alias to apex domain |
+| A | api.goinvoi.com | Points to API Gateway |
+| AAAA | api.goinvoi.com | Points to API Gateway |
+| CNAME | _validation | ACM certificate validation record |
+
+## Security Features
+
+The configuration includes:
+
+- **HTTPS Only** - HTTP automatically redirects to HTTPS
+- **ACM Managed Certificates** - Auto-renewal, no manual cert management
+- **CloudFront HTTPS** - TLS 1.2+ enforced
+- **CORS Protection** - Only allows requests from goinvoi.com in production
+
+## Cost
+
+Custom domain configuration adds minimal cost:
+
+- Route53 Hosted Zone: $0.50/month
+- ACM Certificate: **FREE**
+- CloudFront HTTPS: **FREE**
+- DNS Queries: $0.40 per million queries (effectively free at this scale)
+
+Estimated total: **$0.50/month**
+
+## Next Steps
+
+1. Update Google OAuth credentials with new callback URL
+2. Test the full authentication flow at https://goinvoi.com
+3. Update any hardcoded URLs in frontend code
+4. Monitor CloudFront access logs for traffic patterns
+5. Set up CloudWatch alarms for certificate expiration (optional)

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -53,17 +53,16 @@ export default $config({
 
     // User pool client for React app
     // Configures OAuth flow with environment-specific callback URLs
-    // Note: In dev, uses localhost. In production, uses placeholder that will be replaced
-    // with actual site URL after deployment (Cognito allows updating callback URLs)
+    // In dev: uses localhost. In production: uses goinvoi.com custom domain
     const userPoolClient = userPool.addClient("Web", {
       providers: ["Google"],
       oauth: {
-        // Use localhost for dev, wildcard placeholder for production (update after first deploy)
+        // Use localhost for dev, custom domain for production
         callbackUrls: [
-          $dev ? "http://localhost:5173/auth/callback" : "https://placeholder-update-after-deploy.com/auth/callback"
+          $dev ? "http://localhost:5173/auth/callback" : "https://goinvoi.com/auth/callback"
         ],
         logoutUrls: [
-          $dev ? "http://localhost:5173/auth/logout" : "https://placeholder-update-after-deploy.com/auth/logout"
+          $dev ? "http://localhost:5173/auth/logout" : "https://goinvoi.com/auth/logout"
         ],
         flows: ["authorization_code"], // Standard OAuth 2.0 flow
         scopes: ["email", "openid", "profile"], // Request user's basic info
@@ -95,9 +94,18 @@ export default $config({
     });
 
     // API Gateway + Lambda functions
+    // In production, uses custom domain api.goinvoi.com with ACM certificate
+    // In dev, uses auto-generated API Gateway URL
     const api = new sst.aws.ApiGatewayV2("InvoiApi", {
+      domain: $app.stage === "production" ? {
+        name: "api.goinvoi.com",
+        dns: sst.aws.dns(), // Use Route53 for DNS management
+      } : undefined,
       cors: {
-        allowOrigins: ["*"],
+        // Allow requests from custom domain in production, localhost in dev
+        allowOrigins: $app.stage === "production"
+          ? ["https://goinvoi.com", "https://www.goinvoi.com"]
+          : ["*"],
         allowMethods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
         allowHeaders: ["Content-Type", "Authorization"],
       },
@@ -268,12 +276,20 @@ export default $config({
 
     // Static site (React frontend) - defined after API/Cognito to pass correct env vars
     // These VITE_* variables are exposed to the React app at build time
+    // In production, uses custom domain goinvoi.com with ACM certificate and CloudFront
+    // ACM certificate is created in us-east-1 (required for CloudFront)
+    // DNS validation happens automatically via Route53
     const site = new sst.aws.StaticSite("InvoiWeb", {
       path: "frontend",
       build: {
         command: "npm run build",
         output: "dist",
       },
+      domain: $app.stage === "production" ? {
+        name: "goinvoi.com",
+        aliases: ["www.goinvoi.com"], // Redirect www to apex
+        dns: sst.aws.dns(), // Use Route53 for DNS management
+      } : undefined,
       environment: {
         VITE_API_URL: api.url,
         VITE_COGNITO_USER_POOL_ID: userPool.id,
@@ -292,6 +308,10 @@ export default $config({
       hostedUI: userPool.domainUrl,
       sesIdentity: emailIdentity.email,  // SES verified domain
       sesDkimTokens: domainDkim.dkimTokens,  // DKIM tokens for DNS configuration
+      // Custom domain outputs (production only)
+      // After deploying to production, point your domain registrar to the Route53 nameservers
+      customDomain: $app.stage === "production" ? "goinvoi.com" : "N/A (dev stage)",
+      apiDomain: $app.stage === "production" ? "api.goinvoi.com" : "N/A (dev stage)",
     };
   },
 });


### PR DESCRIPTION
## Work in Progress

Closes #39

[Phase 5] Configure custom domain DNS and SSL

**Time Estimate**: 1hr

**Description**:
Configure goinvoi.com to point to CloudFront distribution with SSL certificate via ACM. Completes the production URL setup.

**Claude Context**:
Files to Read:
- sst.config.ts (CloudFront configuration)
- docs/ADR-webapp-migration.md (domain section)

Files to Modify:
- sst.config.ts (add custom domain configuration)

**Acceptance Criteria**:
- [ ] ACM certificate requested for goinvoi.com and www.goinvoi.com
- [ ] Certificate validated via DNS
- [ ] CloudFront distribution configured with custom domain
- [ ] DNS records point goinvoi.com to CloudFront
- [ ] HTTPS works at https://goinvoi.com
- [ ] HTTP redirects to HTTPS
- [ ] api.goinvoi.com configured for API Gateway (if using subdomain)

**Verification Commands**:
```bash
curl -I https://goinvoi.com
# Should return 200 with CloudFront headers
curl -I http://goinvoi.com
# Should return 301 redirect to HTTPS
```

**Done Definition**: Done when https://goinvoi.com loads the React app with valid SSL.

**Scope Boundary**:
- DO: Configure DNS, SSL, and CloudFront custom domain
- DO NOT: Register the domain (assumed already owned)

**Dependencies**: After "[Phase 5] Create landing page"

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**3** files, **3** commits (+2 added, ~1 modified, -0 deleted)
- `A` CUSTOM-DOMAIN-VALIDATION.md
- `A` DNS-SETUP.md
- `M` sst.config.ts

### Commits
- 817e977 chore: [Phase 5] Configure custom domain DNS and SSL
- 7b987f5 Merge remote-tracking branch 'origin/main' into chore/phase-5-configure-custom-domain-dns-and-ssl
- f5e2a0a chore: initialize work on #39 [Phase 5] Configure custom domain DNS and SSL
<!-- /sharkrite-changes-summary -->