### PR TITLE
Wildcard CORS Origin Allows Any Domain

### DIFF
--- a/backend/functions/config.py
+++ b/backend/functions/config.py
@@ -22,27 +22,19 @@ def handler(event, context):
     POST: Updates user profile in DynamoDB
 
     Both methods require valid JWT in Authorization header.
+
+    Note: CORS is handled by API Gateway (configured in sst.config.ts).
+    Lambda functions should not set CORS headers.
     """
-    # CORS headers for all responses
+    # Response headers
     headers = {
         'Content-Type': 'application/json',
-        'Access-Control-Allow-Origin': '*',
-        'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
-        'Access-Control-Allow-Headers': 'Content-Type, Authorization',
     }
 
     try:
         # Extract HTTP method (supports both API Gateway v1 and v2 formats)
         http_method = event.get('requestContext', {}).get('http', {}).get('method') or event.get('httpMethod', 'GET')
         logger.info(f"Received request: method={http_method} path=/api/config")
-
-        # Handle CORS preflight requests before auth check
-        if http_method == 'OPTIONS':
-            return {
-                'statusCode': 200,
-                'headers': headers,
-                'body': ''
-            }
 
         # Extract userId from JWT claims
         # TODO: Once Cognito is set up in Phase 1, this will come from:

--- a/backend/functions/export.py
+++ b/backend/functions/export.py
@@ -38,26 +38,18 @@ def handler(event, context):
         401: Missing or invalid authorization
         404: One or more invoices not found or not owned by user
         500: Server error
+
+    Note: CORS is handled by API Gateway (configured in sst.config.ts).
+    Lambda functions should not set CORS headers.
     """
-    # CORS headers for all responses
+    # Response headers
     headers = {
         'Content-Type': 'application/json',
-        'Access-Control-Allow-Origin': '*',
-        'Access-Control-Allow-Methods': 'POST, OPTIONS',
-        'Access-Control-Allow-Headers': 'Content-Type, Authorization',
     }
 
     try:
         # Extract HTTP method
         http_method = event.get('requestContext', {}).get('http', {}).get('method') or event.get('httpMethod', 'POST')
-
-        # Handle CORS preflight requests before auth check
-        if http_method == 'OPTIONS':
-            return {
-                'statusCode': 200,
-                'headers': headers,
-                'body': ''
-            }
 
         # Extract userId from JWT claims
         auth_header = event.get('headers', {}).get('authorization') or event.get('headers', {}).get('Authorization')

--- a/backend/functions/hello.py
+++ b/backend/functions/hello.py
@@ -6,14 +6,14 @@ def handler(event, context):
     """
     Lambda handler for GET /hello — end-to-end verification endpoint.
     Returns a simple greeting message to confirm the browser-to-Lambda flow works.
+
+    Note: CORS is handled by API Gateway (configured in sst.config.ts).
+    Lambda functions should not set CORS headers.
     """
     return {
         'statusCode': 200,
         'headers': {
             'Content-Type': 'application/json',
-            'Access-Control-Allow-Origin': '*',  # Will be restricted to CloudFront origin in production
-            'Access-Control-Allow-Methods': 'GET, OPTIONS',
-            'Access-Control-Allow-Headers': 'Content-Type',
         },
         'body': json.dumps({'message': 'Hello from Invoi'})
     }

--- a/backend/functions/import_data.py
+++ b/backend/functions/import_data.py
@@ -250,26 +250,18 @@ def handler(event, context):
     - imported: count of successfully imported invoices
     - failed: count of failed imports
     - errors: array of error messages
+
+    Note: CORS is handled by API Gateway (configured in sst.config.ts).
+    Lambda functions should not set CORS headers.
     """
-    # CORS headers for all responses
+    # Response headers
     headers = {
         'Content-Type': 'application/json',
-        'Access-Control-Allow-Origin': '*',
-        'Access-Control-Allow-Methods': 'POST, OPTIONS',
-        'Access-Control-Allow-Headers': 'Content-Type, Authorization',
     }
 
     try:
         # Extract HTTP method
         http_method = event.get('requestContext', {}).get('http', {}).get('method') or event.get('httpMethod', 'POST')
-
-        # Handle CORS preflight
-        if http_method == 'OPTIONS':
-            return {
-                'statusCode': 200,
-                'headers': headers,
-                'body': ''
-            }
 
         # Extract and validate authorization
         auth_header = event.get('headers', {}).get('authorization') or event.get('headers', {}).get('Authorization')

--- a/backend/functions/invoices.py
+++ b/backend/functions/invoices.py
@@ -27,26 +27,18 @@ def handler(event, context):
         401: Missing or invalid authorization
         404: Invoice not found
         500: Server error
+
+    Note: CORS is handled by API Gateway (configured in sst.config.ts).
+    Lambda functions should not set CORS headers.
     """
-    # CORS headers for all responses
+    # Response headers
     headers = {
         'Content-Type': 'application/json',
-        'Access-Control-Allow-Origin': '*',
-        'Access-Control-Allow-Methods': 'GET, PATCH, OPTIONS',
-        'Access-Control-Allow-Headers': 'Content-Type, Authorization',
     }
 
     try:
         # Extract HTTP method (supports both API Gateway v1 and v2 formats)
         http_method = event.get('requestContext', {}).get('http', {}).get('method') or event.get('httpMethod', 'GET')
-
-        # Handle CORS preflight requests before auth check
-        if http_method == 'OPTIONS':
-            return {
-                'statusCode': 200,
-                'headers': headers,
-                'body': ''
-            }
 
         # Route to appropriate handler based on HTTP method and path
         path_params = event.get('pathParameters', {})

--- a/backend/functions/logo.py
+++ b/backend/functions/logo.py
@@ -61,26 +61,18 @@ def handler(event, context):
     DELETE: Remove logo from S3, clear logoKey from user record
 
     All methods require valid JWT in Authorization header.
+
+    Note: CORS is handled by API Gateway (configured in sst.config.ts).
+    Lambda functions should not set CORS headers.
     """
-    # CORS headers for all responses
+    # Response headers
     headers = {
         'Content-Type': 'application/json',
-        'Access-Control-Allow-Origin': '*',
-        'Access-Control-Allow-Methods': 'GET, POST, DELETE, OPTIONS',
-        'Access-Control-Allow-Headers': 'Content-Type, Authorization',
     }
 
     try:
         # Extract HTTP method (supports both API Gateway v1 and v2 formats)
         http_method = event.get('requestContext', {}).get('http', {}).get('method') or event.get('httpMethod', 'POST')
-
-        # Handle CORS preflight requests before auth check
-        if http_method == 'OPTIONS':
-            return {
-                'statusCode': 200,
-                'headers': headers,
-                'body': ''
-            }
 
         # Extract userId from JWT claims
         auth_header = event.get('headers', {}).get('authorization') or event.get('headers', {}).get('Authorization')

--- a/backend/functions/pdf.py
+++ b/backend/functions/pdf.py
@@ -27,26 +27,18 @@ def handler(event, context):
         401: Missing or invalid authorization
         404: Invoice not found, not owned by user, or PDF not available
         500: Server error
+
+    Note: CORS is handled by API Gateway (configured in sst.config.ts).
+    Lambda functions should not set CORS headers.
     """
-    # CORS headers for all responses
+    # Response headers
     headers = {
         'Content-Type': 'application/json',
-        'Access-Control-Allow-Origin': '*',
-        'Access-Control-Allow-Methods': 'GET, OPTIONS',
-        'Access-Control-Allow-Headers': 'Content-Type, Authorization',
     }
 
     try:
         # Extract HTTP method (supports both API Gateway v1 and v2 formats)
         http_method = event.get('requestContext', {}).get('http', {}).get('method') or event.get('httpMethod', 'GET')
-
-        # Handle CORS preflight requests before auth check
-        if http_method == 'OPTIONS':
-            return {
-                'statusCode': 200,
-                'headers': headers,
-                'body': ''
-            }
 
         # Extract userId from JWT claims
         auth_header = event.get('headers', {}).get('authorization') or event.get('headers', {}).get('Authorization')

--- a/backend/functions/resend.py
+++ b/backend/functions/resend.py
@@ -34,26 +34,18 @@ def handler(event, context):
         401: Missing or invalid authorization
         404: One or more invoices not found or not owned by user
         500: Server error
+
+    Note: CORS is handled by API Gateway (configured in sst.config.ts).
+    Lambda functions should not set CORS headers.
     """
-    # CORS headers for all responses
+    # Response headers
     headers = {
         'Content-Type': 'application/json',
-        'Access-Control-Allow-Origin': '*',
-        'Access-Control-Allow-Methods': 'POST, OPTIONS',
-        'Access-Control-Allow-Headers': 'Content-Type, Authorization',
     }
 
     try:
         # Extract HTTP method
         http_method = event.get('requestContext', {}).get('http', {}).get('method') or event.get('httpMethod', 'POST')
-
-        # Handle CORS preflight requests before auth check
-        if http_method == 'OPTIONS':
-            return {
-                'statusCode': 200,
-                'headers': headers,
-                'body': ''
-            }
 
         # Extract userId from JWT claims
         auth_header = event.get('headers', {}).get('authorization') or event.get('headers', {}).get('Authorization')

--- a/backend/functions/scan_month.py
+++ b/backend/functions/scan_month.py
@@ -26,26 +26,18 @@ def handler(event, context):
         400: Invalid query parameters
         401: Missing or invalid authorization
         500: Server error
+
+    Note: CORS is handled by API Gateway (configured in sst.config.ts).
+    Lambda functions should not set CORS headers.
     """
-    # CORS headers for all responses
+    # Response headers
     headers = {
         'Content-Type': 'application/json',
-        'Access-Control-Allow-Origin': '*',
-        'Access-Control-Allow-Methods': 'GET, OPTIONS',
-        'Access-Control-Allow-Headers': 'Content-Type, Authorization',
     }
 
     try:
         # Extract HTTP method (supports both API Gateway v1 and v2 formats)
         http_method = event.get('requestContext', {}).get('http', {}).get('method') or event.get('httpMethod', 'GET')
-
-        # Handle CORS preflight requests before auth check
-        if http_method == 'OPTIONS':
-            return {
-                'statusCode': 200,
-                'headers': headers,
-                'body': ''
-            }
 
         # Extract userId from JWT claims
         auth_header = event.get('headers', {}).get('authorization') or event.get('headers', {}).get('Authorization')

--- a/backend/functions/submit_monthly.py
+++ b/backend/functions/submit_monthly.py
@@ -41,26 +41,18 @@ def handler(event, context):
         400: Invalid request parameters
         401: Missing or invalid authorization
         500: Server error
+
+    Note: CORS is handled by API Gateway (configured in sst.config.ts).
+    Lambda functions should not set CORS headers.
     """
-    # CORS headers for all responses
+    # Response headers
     headers = {
         'Content-Type': 'application/json',
-        'Access-Control-Allow-Origin': '*',
-        'Access-Control-Allow-Methods': 'POST, OPTIONS',
-        'Access-Control-Allow-Headers': 'Content-Type, Authorization',
     }
 
     try:
         # Extract HTTP method (supports both API Gateway v1 and v2 formats)
         http_method = event.get('requestContext', {}).get('http', {}).get('method') or event.get('httpMethod', 'POST')
-
-        # Handle CORS preflight requests before auth check
-        if http_method == 'OPTIONS':
-            return {
-                'statusCode': 200,
-                'headers': headers,
-                'body': ''
-            }
 
         # Extract userId from JWT claims
         auth_header = event.get('headers', {}).get('authorization') or event.get('headers', {}).get('Authorization')

--- a/backend/functions/submit_weekly.py
+++ b/backend/functions/submit_weekly.py
@@ -44,26 +44,18 @@ def handler(event, context):
         400: Invalid request parameters
         401: Missing or invalid authorization
         500: Server error
+
+    Note: CORS is handled by API Gateway (configured in sst.config.ts).
+    Lambda functions should not set CORS headers.
     """
-    # CORS headers for all responses
+    # Response headers
     headers = {
         'Content-Type': 'application/json',
-        'Access-Control-Allow-Origin': '*',
-        'Access-Control-Allow-Methods': 'POST, OPTIONS',
-        'Access-Control-Allow-Headers': 'Content-Type, Authorization',
     }
 
     try:
         # Extract HTTP method (supports both API Gateway v1 and v2 formats)
         http_method = event.get('requestContext', {}).get('http', {}).get('method') or event.get('httpMethod', 'POST')
-
-        # Handle CORS preflight requests before auth check
-        if http_method == 'OPTIONS':
-            return {
-                'statusCode': 200,
-                'headers': headers,
-                'body': ''
-            }
 
         # Extract userId from JWT claims
         auth_header = event.get('headers', {}).get('authorization') or event.get('headers', {}).get('Authorization')

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -324,20 +324,42 @@ class TestValidation:
 
 
 class TestCORS:
-    """Tests for CORS handling"""
+    """Tests for CORS handling
 
-    def test_options_request_returns_200(self):
-        """OPTIONS preflight request should return 200 with CORS headers"""
+    Note: CORS is now handled by API Gateway (configured in sst.config.ts).
+    Lambda functions no longer set CORS headers directly.
+    API Gateway automatically adds CORS headers based on the configuration.
+    """
+
+    def test_lambda_response_has_no_cors_headers(self):
+        """Lambda responses should not include CORS headers (API Gateway handles them)"""
         event = {
             'requestContext': {
-                'http': {'method': 'OPTIONS'}
+                'http': {'method': 'GET'},
+                'authorizer': {
+                    'jwt': {
+                        'claims': {'sub': 'user-123'}
+                    }
+                }
             },
             'headers': {'Authorization': 'Bearer valid-token'}
         }
 
-        response = handler(event, {})
+        # Mock existing user data
+        mock_user = {
+            'userId': 'user-123',
+            'name': 'Test User',
+            'email': 'test@example.com',
+            'rate': 25.0
+        }
+
+        with patch('functions.config.get_user', return_value=mock_user):
+            response = handler(event, {})
 
         assert response['statusCode'] == 200
-        assert 'Access-Control-Allow-Origin' in response['headers']
-        assert 'Access-Control-Allow-Methods' in response['headers']
-        assert 'Access-Control-Allow-Headers' in response['headers']
+        # Lambda should NOT set CORS headers - API Gateway handles them
+        assert 'Access-Control-Allow-Origin' not in response['headers']
+        assert 'Access-Control-Allow-Methods' not in response['headers']
+        assert 'Access-Control-Allow-Headers' not in response['headers']
+        # But Content-Type should still be set
+        assert response['headers']['Content-Type'] == 'application/json'

--- a/backend/tests/test_export.py
+++ b/backend/tests/test_export.py
@@ -610,40 +610,54 @@ class TestAuthAndValidation:
 
 
 class TestCORS:
-    """Tests for CORS handling"""
+    """Tests for CORS handling
 
-    def test_options_request_returns_200(self):
-        """OPTIONS preflight request should return 200 with CORS headers"""
+    Note: CORS is now handled by API Gateway (configured in sst.config.ts).
+    Lambda functions no longer set CORS headers directly.
+    API Gateway automatically adds CORS headers based on the configuration.
+    """
+
+    def test_lambda_response_has_no_cors_headers(self):
+        """Lambda responses should not include CORS headers (API Gateway handles them)"""
         event = {
             'requestContext': {
-                'http': {'method': 'OPTIONS'}
+                'http': {'method': 'POST'},
+                'authorizer': {
+                    'jwt': {
+                        'claims': {'sub': 'user-123'}
+                    }
+                }
             },
-            'headers': {'Authorization': 'Bearer valid-token'}
-        }
-
-        response = handler(event, {})
-
-        assert response['statusCode'] == 200
-        assert 'Access-Control-Allow-Origin' in response['headers']
-        assert 'Access-Control-Allow-Methods' in response['headers']
-        assert 'Access-Control-Allow-Headers' in response['headers']
-        assert 'POST' in response['headers']['Access-Control-Allow-Methods']
-
-    def test_all_responses_include_cors_headers(self):
-        """All responses should include CORS headers"""
-        event = {
-            'requestContext': {'http': {'method': 'POST'}},
-            'headers': {},  # Missing auth to trigger 401
+            'headers': {'Authorization': 'Bearer valid-token'},
             'body': json.dumps({
-                'invoiceIds': ['INV-001'],
+                'invoiceIds': ['INV-20260324'],
                 'format': 'csv'
             })
         }
 
-        response = handler(event, {})
+        mock_invoice = {
+            'userId': 'user-123',
+            'invoiceId': 'INV-20260324',
+            'weekStart': '2026-03-24',
+            'weekEnd': '2026-03-30',
+            'totalHours': 40,
+            'totalPay': 1000.00
+        }
 
-        assert 'Access-Control-Allow-Origin' in response['headers']
-        assert response['headers']['Access-Control-Allow-Origin'] == '*'
+        with patch.dict(os.environ, {'InvoiStorage': 'test-bucket'}):
+            with patch('functions.export.get_invoice', return_value=mock_invoice):
+                with patch('functions.export.s3_client') as mock_s3:
+                    mock_s3.put_object.return_value = {}
+                    mock_s3.generate_presigned_url.return_value = 'https://s3.amazonaws.com/signed-url'
+                    response = handler(event, {})
+
+        assert response['statusCode'] == 200
+        # Lambda should NOT set CORS headers - API Gateway handles them
+        assert 'Access-Control-Allow-Origin' not in response['headers']
+        assert 'Access-Control-Allow-Methods' not in response['headers']
+        assert 'Access-Control-Allow-Headers' not in response['headers']
+        # But Content-Type should still be set
+        assert response['headers']['Content-Type'] == 'application/json'
 
 
 class TestErrorHandling:

--- a/backend/tests/test_import_data.py
+++ b/backend/tests/test_import_data.py
@@ -1,0 +1,61 @@
+"""
+Unit tests for import_data.py Lambda function
+
+Tests historical invoice import functionality.
+"""
+import pytest
+import json
+import sys
+import os
+from unittest.mock import Mock, patch, MagicMock
+
+# Add parent directory to path for imports
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from functions.import_data import handler
+
+
+class TestImportDataCORS:
+    """
+    Test that import_data Lambda function does NOT set CORS headers.
+    Lambda functions no longer set CORS headers directly.
+    API Gateway automatically adds CORS headers based on the configuration.
+    """
+
+    def test_lambda_response_has_no_cors_headers(self):
+        """Lambda responses should not include CORS headers (API Gateway handles them)"""
+        event = {
+            'requestContext': {
+                'http': {'method': 'POST'},
+                'authorizer': {
+                    'jwt': {
+                        'claims': {'sub': 'user-123'}
+                    }
+                }
+            },
+            'headers': {
+                'Authorization': 'Bearer valid-token',
+                'content-type': 'multipart/form-data; boundary=----WebKitFormBoundary123'
+            },
+            'body': '------WebKitFormBoundary123\r\nContent-Disposition: form-data; name="jsons"; filename="invoice-001.json"\r\nContent-Type: application/json\r\n\r\n{"invoiceNumber":"INV-001","date":"2026-03-24","amount":1120}\r\n------WebKitFormBoundary123\r\nContent-Disposition: form-data; name="pdfs"; filename="invoice-001.pdf"\r\nContent-Type: application/pdf\r\n\r\n%PDF-1.4\nfake content\r\n------WebKitFormBoundary123--\r\n'
+        }
+
+        # Mock user
+        mock_user = {
+            'userId': 'user-123',
+            'name': 'Test User'
+        }
+
+        with patch('functions.import_data.get_user', return_value=mock_user):
+            with patch('functions.import_data.s3_client'):
+                with patch('functions.import_data.put_invoice'):
+                    with patch.dict(os.environ, {'SST_Resource_InvoiStorage_name': 'test-bucket'}):
+                        response = handler(event, {})
+
+        assert response['statusCode'] == 200
+        # Lambda should NOT set CORS headers - API Gateway handles them
+        assert 'Access-Control-Allow-Origin' not in response['headers']
+        assert 'Access-Control-Allow-Methods' not in response['headers']
+        assert 'Access-Control-Allow-Headers' not in response['headers']
+        # But Content-Type should still be set
+        assert response['headers']['Content-Type'] == 'application/json'

--- a/backend/tests/test_invoices.py
+++ b/backend/tests/test_invoices.py
@@ -854,22 +854,39 @@ class TestGetSingleInvoice:
 
 
 class TestCORS:
-    """Tests for CORS handling"""
+    """Tests for CORS handling
 
-    def test_options_request_returns_200(self):
-        """OPTIONS preflight request should return 200 with CORS headers"""
+    Note: CORS is now handled by API Gateway (configured in sst.config.ts).
+    Lambda functions no longer set CORS headers directly.
+    API Gateway automatically adds CORS headers based on the configuration.
+    """
+
+    def test_lambda_response_has_no_cors_headers(self):
+        """Lambda responses should not include CORS headers (API Gateway handles them)"""
         event = {
             'requestContext': {
-                'http': {'method': 'OPTIONS'}
+                'http': {'method': 'GET'},
+                'authorizer': {
+                    'jwt': {
+                        'claims': {'sub': 'user-123'}
+                    }
+                }
             },
-            'headers': {'Authorization': 'Bearer valid-token'}
+            'headers': {'Authorization': 'Bearer valid-token'},
+            'queryStringParameters': None
         }
 
-        response = handler(event, {})
+        mock_invoices = [
+            {'userId': 'user-123', 'invoiceId': 'INV-20260324', 'status': 'sent', 'totalPay': 1120.00},
+        ]
+
+        with patch('functions.invoices.query_invoices', return_value=mock_invoices):
+            response = handler(event, {})
 
         assert response['statusCode'] == 200
-        assert 'Access-Control-Allow-Origin' in response['headers']
-        assert 'Access-Control-Allow-Methods' in response['headers']
-        assert 'Access-Control-Allow-Headers' in response['headers']
-        assert 'GET' in response['headers']['Access-Control-Allow-Methods']
-        assert 'PATCH' in response['headers']['Access-Control-Allow-Methods']
+        # Lambda should NOT set CORS headers - API Gateway handles them
+        assert 'Access-Control-Allow-Origin' not in response['headers']
+        assert 'Access-Control-Allow-Methods' not in response['headers']
+        assert 'Access-Control-Allow-Headers' not in response['headers']
+        # But Content-Type should still be set
+        assert response['headers']['Content-Type'] == 'application/json'

--- a/backend/tests/test_logo.py
+++ b/backend/tests/test_logo.py
@@ -1,0 +1,128 @@
+"""
+Unit tests for logo.py Lambda function
+
+Tests logo upload, retrieval, and deletion functionality.
+"""
+import pytest
+import json
+import sys
+import os
+from unittest.mock import Mock, patch, MagicMock
+
+# Add parent directory to path for imports
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from functions.logo import handler
+
+
+class TestLogoCORS:
+    """
+    Test that logo Lambda function does NOT set CORS headers.
+    Lambda functions no longer set CORS headers directly.
+    API Gateway automatically adds CORS headers based on the configuration.
+    """
+
+    def test_lambda_response_has_no_cors_headers_get(self):
+        """Lambda GET responses should not include CORS headers (API Gateway handles them)"""
+        event = {
+            'requestContext': {
+                'http': {'method': 'GET'},
+                'authorizer': {
+                    'jwt': {
+                        'claims': {'sub': 'user-123'}
+                    }
+                }
+            },
+            'headers': {'Authorization': 'Bearer valid-token'}
+        }
+
+        # Mock user with no logo
+        mock_user = {
+            'userId': 'user-123',
+            'name': 'Test User'
+        }
+
+        with patch('functions.logo.get_user', return_value=mock_user):
+            with patch.dict(os.environ, {'SST_Resource_InvoiStorage_name': 'test-bucket'}):
+                response = handler(event, {})
+
+        assert response['statusCode'] == 404
+        # Lambda should NOT set CORS headers - API Gateway handles them
+        assert 'Access-Control-Allow-Origin' not in response['headers']
+        assert 'Access-Control-Allow-Methods' not in response['headers']
+        assert 'Access-Control-Allow-Headers' not in response['headers']
+        # But Content-Type should still be set
+        assert response['headers']['Content-Type'] == 'application/json'
+
+    def test_lambda_response_has_no_cors_headers_post(self):
+        """Lambda POST responses should not include CORS headers (API Gateway handles them)"""
+        event = {
+            'requestContext': {
+                'http': {'method': 'POST'},
+                'authorizer': {
+                    'jwt': {
+                        'claims': {'sub': 'user-123'}
+                    }
+                }
+            },
+            'headers': {'Authorization': 'Bearer valid-token'},
+            'body': json.dumps({
+                'imageData': 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
+                'logoSize': 'medium'
+            })
+        }
+
+        # Mock user
+        mock_user = {
+            'userId': 'user-123',
+            'name': 'Test User'
+        }
+
+        with patch('functions.logo.get_user', return_value=mock_user):
+            with patch('functions.logo.s3_client'):
+                with patch('functions.logo.put_user'):
+                    with patch.dict(os.environ, {'SST_Resource_InvoiStorage_name': 'test-bucket'}):
+                        response = handler(event, {})
+
+        assert response['statusCode'] == 200
+        # Lambda should NOT set CORS headers - API Gateway handles them
+        assert 'Access-Control-Allow-Origin' not in response['headers']
+        assert 'Access-Control-Allow-Methods' not in response['headers']
+        assert 'Access-Control-Allow-Headers' not in response['headers']
+        # But Content-Type should still be set
+        assert response['headers']['Content-Type'] == 'application/json'
+
+    def test_lambda_response_has_no_cors_headers_delete(self):
+        """Lambda DELETE responses should not include CORS headers (API Gateway handles them)"""
+        event = {
+            'requestContext': {
+                'http': {'method': 'DELETE'},
+                'authorizer': {
+                    'jwt': {
+                        'claims': {'sub': 'user-123'}
+                    }
+                }
+            },
+            'headers': {'Authorization': 'Bearer valid-token'}
+        }
+
+        # Mock user with logo
+        mock_user = {
+            'userId': 'user-123',
+            'name': 'Test User',
+            'logoKey': 'users/user-123/logo.png'
+        }
+
+        with patch('functions.logo.get_user', return_value=mock_user):
+            with patch('functions.logo.s3_client'):
+                with patch('functions.logo.put_user'):
+                    with patch.dict(os.environ, {'SST_Resource_InvoiStorage_name': 'test-bucket'}):
+                        response = handler(event, {})
+
+        assert response['statusCode'] == 200
+        # Lambda should NOT set CORS headers - API Gateway handles them
+        assert 'Access-Control-Allow-Origin' not in response['headers']
+        assert 'Access-Control-Allow-Methods' not in response['headers']
+        assert 'Access-Control-Allow-Headers' not in response['headers']
+        # But Content-Type should still be set
+        assert response['headers']['Content-Type'] == 'application/json'

--- a/backend/tests/test_pdf.py
+++ b/backend/tests/test_pdf.py
@@ -404,34 +404,44 @@ class TestGetPdfUrl:
 
 
 class TestCORS:
-    """Tests for CORS handling"""
+    """Tests for CORS handling
 
-    def test_options_request_returns_200(self):
-        """OPTIONS preflight request should return 200 with CORS headers"""
+    Note: CORS is now handled by API Gateway (configured in sst.config.ts).
+    Lambda functions no longer set CORS headers directly.
+    API Gateway automatically adds CORS headers based on the configuration.
+    """
+
+    def test_lambda_response_has_no_cors_headers(self):
+        """Lambda responses should not include CORS headers (API Gateway handles them)"""
         event = {
             'requestContext': {
-                'http': {'method': 'OPTIONS'}
+                'http': {'method': 'GET'},
+                'authorizer': {
+                    'jwt': {
+                        'claims': {'sub': 'user-123'}
+                    }
+                }
             },
-            'headers': {'Authorization': 'Bearer valid-token'}
-        }
-
-        response = handler(event, {})
-
-        assert response['statusCode'] == 200
-        assert 'Access-Control-Allow-Origin' in response['headers']
-        assert 'Access-Control-Allow-Methods' in response['headers']
-        assert 'Access-Control-Allow-Headers' in response['headers']
-        assert 'GET' in response['headers']['Access-Control-Allow-Methods']
-
-    def test_all_responses_include_cors_headers(self):
-        """All responses should include CORS headers"""
-        event = {
-            'requestContext': {'http': {'method': 'GET'}},
-            'headers': {},  # Missing auth to trigger 401
+            'headers': {'Authorization': 'Bearer valid-token'},
             'pathParameters': {'id': 'INV-20260324'}
         }
 
-        response = handler(event, {})
+        mock_invoice = {
+            'userId': 'user-123',
+            'invoiceId': 'INV-20260324',
+            'pdfKey': 'invoices/user-123/INV-20260324.pdf'
+        }
 
-        assert 'Access-Control-Allow-Origin' in response['headers']
-        assert response['headers']['Access-Control-Allow-Origin'] == '*'
+        with patch.dict(os.environ, {'InvoiStorage': 'test-bucket'}):
+            with patch('functions.pdf.get_invoice', return_value=mock_invoice):
+                with patch('functions.pdf.s3_client') as mock_s3:
+                    mock_s3.generate_presigned_url.return_value = 'https://s3.amazonaws.com/signed-url'
+                    response = handler(event, {})
+
+        assert response['statusCode'] == 200
+        # Lambda should NOT set CORS headers - API Gateway handles them
+        assert 'Access-Control-Allow-Origin' not in response['headers']
+        assert 'Access-Control-Allow-Methods' not in response['headers']
+        assert 'Access-Control-Allow-Headers' not in response['headers']
+        # But Content-Type should still be set
+        assert response['headers']['Content-Type'] == 'application/json'

--- a/backend/tests/test_resend.py
+++ b/backend/tests/test_resend.py
@@ -276,7 +276,9 @@ class TestResendHandler:
         body = json.loads(response['body'])
         assert 'Cannot resend more than' in body['error']
 
-    def test_lambda_response_has_no_cors_headers(self):
+    @patch('functions.resend.get_user')
+    @patch('functions.resend.get_invoice')
+    def test_lambda_response_has_no_cors_headers(self, mock_get_invoice, mock_get_user):
         """Lambda responses should not include CORS headers (API Gateway handles them)"""
         event = {
             'requestContext': {
@@ -305,9 +307,7 @@ class TestResendHandler:
 
         os.environ['InvoiStorage'] = 'test-bucket'
 
-        with patch('functions.resend.get_user', return_value=mock_get_user.return_value):
-            with patch('functions.resend.get_invoice', return_value=None):
-                response = handler(event, {})
+        response = handler(event, {})
 
         assert response['statusCode'] == 200
         # Lambda should NOT set CORS headers - API Gateway handles them

--- a/backend/tests/test_resend.py
+++ b/backend/tests/test_resend.py
@@ -276,15 +276,43 @@ class TestResendHandler:
         body = json.loads(response['body'])
         assert 'Cannot resend more than' in body['error']
 
-    def test_resend_cors_preflight(self):
-        """Test CORS preflight OPTIONS request"""
+    def test_lambda_response_has_no_cors_headers(self):
+        """Lambda responses should not include CORS headers (API Gateway handles them)"""
         event = {
-            'requestContext': {'http': {'method': 'OPTIONS'}},
-            'headers': {}
+            'requestContext': {
+                'http': {'method': 'POST'},
+                'authorizer': {
+                    'jwt': {
+                        'claims': {'sub': 'user-123'}
+                    }
+                }
+            },
+            'headers': {'Authorization': 'Bearer token'},
+            'body': json.dumps({
+                'invoiceIds': ['INV-001']
+            })
         }
 
-        response = handler(event, {})
+        # Mock user config
+        mock_get_user.return_value = {
+            'userId': 'user-123',
+            'name': 'Lisa Wadley',
+            'clients': []
+        }
+
+        # Mock invoice not found to get quick response
+        mock_get_invoice.return_value = None
+
+        os.environ['InvoiStorage'] = 'test-bucket'
+
+        with patch('functions.resend.get_user', return_value=mock_get_user.return_value):
+            with patch('functions.resend.get_invoice', return_value=None):
+                response = handler(event, {})
 
         assert response['statusCode'] == 200
-        assert response['headers']['Access-Control-Allow-Origin'] == '*'
-        assert response['headers']['Access-Control-Allow-Methods'] == 'POST, OPTIONS'
+        # Lambda should NOT set CORS headers - API Gateway handles them
+        assert 'Access-Control-Allow-Origin' not in response['headers']
+        assert 'Access-Control-Allow-Methods' not in response['headers']
+        assert 'Access-Control-Allow-Headers' not in response['headers']
+        # But Content-Type should still be set
+        assert response['headers']['Content-Type'] == 'application/json'

--- a/backend/tests/test_scan_month.py
+++ b/backend/tests/test_scan_month.py
@@ -408,20 +408,42 @@ class TestScanMonth:
 
 
 class TestCORS:
-    """Tests for CORS handling"""
+    """Tests for CORS handling
 
-    def test_options_request_returns_200(self):
-        """OPTIONS preflight request should return 200 with CORS headers"""
+    Note: CORS is now handled by API Gateway (configured in sst.config.ts).
+    Lambda functions no longer set CORS headers directly.
+    API Gateway automatically adds CORS headers based on the configuration.
+    """
+
+    def test_lambda_response_has_no_cors_headers(self):
+        """Lambda responses should not include CORS headers (API Gateway handles them)"""
         event = {
             'requestContext': {
-                'http': {'method': 'OPTIONS'}
+                'http': {'method': 'GET'},
+                'authorizer': {
+                    'jwt': {
+                        'claims': {'sub': 'user-123'}
+                    }
+                }
             },
-            'headers': {'Authorization': 'Bearer valid-token'}
+            'headers': {'Authorization': 'Bearer valid-token'},
+            'queryStringParameters': {
+                'year': '2026',
+                'month': '3'
+            }
         }
 
-        response = handler(event, {})
+        mock_invoices = [
+            {'userId': 'user-123', 'invoiceId': 'INV-20260324', 'status': 'sent'},
+        ]
+
+        with patch('functions.scan_month.query_invoices', return_value=mock_invoices):
+            response = handler(event, {})
 
         assert response['statusCode'] == 200
-        assert 'Access-Control-Allow-Origin' in response['headers']
-        assert 'Access-Control-Allow-Methods' in response['headers']
-        assert 'Access-Control-Allow-Headers' in response['headers']
+        # Lambda should NOT set CORS headers - API Gateway handles them
+        assert 'Access-Control-Allow-Origin' not in response['headers']
+        assert 'Access-Control-Allow-Methods' not in response['headers']
+        assert 'Access-Control-Allow-Headers' not in response['headers']
+        # But Content-Type should still be set
+        assert response['headers']['Content-Type'] == 'application/json'

--- a/backend/tests/test_submit_monthly.py
+++ b/backend/tests/test_submit_monthly.py
@@ -274,3 +274,63 @@ class TestSubmitMonthly:
         assert 'SES error' in body['emailWarning']
         assert body['sent'] == []
         assert body['status'] == 'draft'  # Status should remain draft since email failed
+
+    def test_lambda_response_has_no_cors_headers(self):
+        """Lambda responses should not include CORS headers (API Gateway handles them)"""
+        event = {
+            'requestContext': {
+                'http': {'method': 'POST'},
+                'authorizer': {
+                    'jwt': {
+                        'claims': {'sub': 'user-123'}
+                    }
+                }
+            },
+            'headers': {'Authorization': 'Bearer valid-token'},
+            'body': json.dumps({
+                'year': 2026,
+                'month': 3,
+                'send': False,
+                'accountantEmail': 'accountant@example.com'
+            })
+        }
+
+        # Mock user config
+        mock_user = {
+            'userId': 'user-123',
+            'name': 'Test User',
+            'rate': 28.00,
+            'template': 'morning-light',
+            'signatureFont': 'Dancing Script'
+        }
+
+        # Mock weekly invoices
+        mock_weekly_invoices = [
+            {
+                'invoiceId': 'INV-20260301',
+                'weekStart': '2026-03-01',
+                'weekEnd': '2026-03-07',
+                'totalHours': 40
+            }
+        ]
+
+        # Mock PDF generation
+        mock_pdf_bytes = b'%PDF-1.4\nMock PDF content'
+
+        with patch.dict(os.environ, {
+            'SST_Resource_InvoiStorage_name': 'test-bucket'
+        }):
+            with patch('functions.submit_monthly.get_user', return_value=mock_user):
+                with patch('functions.submit_monthly.query_invoices', return_value=mock_weekly_invoices):
+                    with patch('functions.submit_monthly.generate_monthly_report', return_value=mock_pdf_bytes):
+                        with patch('functions.submit_monthly.save_pdf_to_s3'):
+                            with patch('functions.submit_monthly.put_invoice'):
+                                response = handler(event, {})
+
+        assert response['statusCode'] == 200
+        # Lambda should NOT set CORS headers - API Gateway handles them
+        assert 'Access-Control-Allow-Origin' not in response['headers']
+        assert 'Access-Control-Allow-Methods' not in response['headers']
+        assert 'Access-Control-Allow-Headers' not in response['headers']
+        # But Content-Type should still be set
+        assert response['headers']['Content-Type'] == 'application/json'

--- a/backend/tests/test_submit_weekly.py
+++ b/backend/tests/test_submit_weekly.py
@@ -350,18 +350,97 @@ class TestSubmitWeekly:
         # Total = $1623.75
         assert body['totalPay'] == 1623.75
 
-    def test_cors_preflight(self):
-        """OPTIONS request should return 200 with CORS headers"""
+    def test_lambda_response_has_no_cors_headers(self):
+        """Lambda responses should not include CORS headers (API Gateway handles them)"""
         event = {
-            'requestContext': {'http': {'method': 'OPTIONS'}},
-            'headers': {}
+            'requestContext': {
+                'http': {'method': 'POST'},
+                'authorizer': {
+                    'jwt': {
+                        'claims': {'sub': 'user-123'}
+                    }
+                }
+            },
+            'headers': {'Authorization': 'Bearer valid-token'},
+            'body': json.dumps({
+                'hours': {
+                    'Monday': 8,
+                    'Tuesday': 8,
+                    'Wednesday': 8,
+                    'Thursday': 8,
+                    'Friday': 8,
+                    'Saturday': 0,
+                    'Sunday': 0
+                },
+                'week': {
+                    'start': '2026-03-24',
+                    'end': '2026-03-30',
+                    'invNum': 'INV-20260324'
+                },
+                'clientEmail': 'client@example.com',
+                'accountantEmail': 'accountant@example.com',
+                'saveOnly': True
+            })
         }
 
-        response = handler(event, {})
+        # Mock user config with all required fields
+        mock_user = {
+            'userId': 'user-123',
+            'name': 'Test User',
+            'address': '123 Main St',
+            'personalEmail': 'test@example.com',
+            'rate': 28.00,
+            'template': 'morning-light',
+            'signatureFont': 'Dancing Script',
+            'paymentTerms': 'receipt',
+            'taxEnabled': False,
+            'invoiceNumberConfig': {
+                'prefix': 'INV',
+                'includeYear': False,
+                'separator': '-',
+                'padding': 3,
+                'nextNum': 1
+            },
+            'activeClientId': 'client-1',
+            'clients': [
+                {
+                    'id': 'client-1',
+                    'name': 'Test Client',
+                    'email': 'client@example.com'
+                }
+            ]
+        }
+
+        # Mock PDF generation returning bytes
+        mock_pdf_bytes = b'%PDF-1.4\nMock PDF content'
+
+        with patch.dict(os.environ, {
+            'USERS_TABLE': 'users-table',
+            'INVOICES_TABLE': 'invoices-table',
+            'SST_Resource_InvoiStorage_name': 'test-bucket'
+        }):
+            with patch('functions.submit_weekly.get_user', return_value=mock_user):
+                with patch('functions.submit_weekly.generate_weekly_invoice', return_value=mock_pdf_bytes):
+                    with patch('functions.submit_weekly.save_pdf_to_s3'):
+                        with patch('functions.submit_weekly.boto3.client') as mock_boto_client:
+                            with patch('functions.submit_weekly.boto3.resource') as mock_boto_resource:
+                                # Mock DynamoDB client for TransactWriteItems
+                                mock_dynamodb_client = MagicMock()
+                                mock_boto_client.return_value = mock_dynamodb_client
+
+                                # Mock DynamoDB resource for put_item
+                                mock_table = MagicMock()
+                                mock_boto_resource.return_value.Table.return_value = mock_table
+
+                                response = handler(event, {})
 
         assert response['statusCode'] == 200
-        assert 'Access-Control-Allow-Origin' in response['headers']
-        assert response['headers']['Access-Control-Allow-Origin'] == '*'
+        # Lambda should NOT set CORS headers - API Gateway handles them
+        assert 'Access-Control-Allow-Origin' not in response['headers']
+        assert 'Access-Control-Allow-Methods' not in response['headers']
+        assert 'Access-Control-Allow-Headers' not in response['headers']
+        # But Content-Type should still be set
+        assert response['headers']['Content-Type'] == 'application/json'
 
     def test_calculate_due_date_receipt(self):
         """Due date calculation for 'receipt' payment terms"""

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -109,7 +109,7 @@ export default $config({
         allowOrigins: $app.stage === "production"
           ? ["https://goinvoi.com", "https://www.goinvoi.com"]
           : ["*"],
-        allowMethods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+        allowMethods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
         allowHeaders: ["Content-Type", "Authorization"],
       },
       transform: {


### PR DESCRIPTION
## Work in Progress

Closes #59

Wildcard CORS Origin Allows Any Domain

<!-- sharkrite-source-issue:10 -->## From PR #58 Assessment

**Severity:** HIGH
**Category:** Security

## Issue
While this is a security concern, the JWT validation provides the primary authentication layer. The wildcard CORS is a defense-in-depth issue rather than an exploitable vulnerability since credentials are not automatically included with wildcard origins.

## Context
The original issue scope focuses on implementing the POST handler with validation and auth checks. CORS hardening is infrastructure configuration that should be addressed consistently across all endpoints, not just this one.

## Defer Reason
Scope exceeds time budget - CORS policy should be configured at the API Gateway/SST level for consistency across all endpoints, not per-handler

---
_Created by Sharkrite assessment on 2026-04-03T12:34:38Z_
_Parent PR: #58_

---

## Additional Assessment (PR #90)

**Severity:** MEDIUM
**Reasoning:** While `Access-Control-Allow-Origin: *` is a valid concern for production hardening, JWT authorization already protects the endpoint. This is a defense-in-depth improvement, not a blocking vulnerability. Other endpoints in the codebase likely use the same pattern, making this a codebase-wide concern rather than specific to this PR.
**Context:** The original issue scope focuses on implementing the PDF download endpoint functionality, not production CORS hardening. This is real but out of scope.
**Defer Reason:** Scope exceeds time budget — requires audit of all endpoints and consistent CORS configuration strategy

_Added by Sharkrite on 2026-04-04T09:38:15Z_

---

## Additional Assessment (PR #111)

**Severity:** MEDIUM
**Reasoning:** Valid security improvement but not blocking for initial deployment. The endpoint is already protected by JWT authentication, so the wildcard CORS does not expose unauthenticated access.
**Context:** Out of scope for the import feature itself; CORS configuration is an infrastructure concern that should be addressed consistently across all endpoints.
**Defer Reason:** Needs separate focused PR to address CORS configuration consistently across all backend functions

_Added by Sharkrite on 2026-04-04T18:38:13Z_

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**23** files, **2** commits (+0 added, ~22 modified, -1 deleted)
- `M` backend/functions/config.py
- `M` backend/functions/export.py
- `M` backend/functions/hello.py
- `M` backend/functions/import_data.py
- `M` backend/functions/invoices.py
- `M` backend/functions/logo.py
- `M` backend/functions/pdf.py
- `M` backend/functions/resend.py
- `M` backend/functions/scan_month.py
- `M` backend/functions/submit_monthly.py
- `M` backend/functions/submit_weekly.py
- `M` backend/tests/test_config.py
- `M` backend/tests/test_export.py
- `M` backend/tests/test_invoices.py
- `M` backend/tests/test_pdf.py
- `M` backend/tests/test_scan_month.py
- `M` frontend/src/App.jsx
- `M` frontend/src/components/ImportPage.jsx
- `M` frontend/src/components/LandingPage.jsx
- `M` frontend/src/components/PrivacyPolicy.jsx
- `M` frontend/src/components/TermsOfService.jsx
- `M` frontend/src/components/WelcomePage.jsx
- `D` frontend/src/theme.js

### Commits
- 06b1190 feat: Wildcard CORS Origin Allows Any Domain
- 2473ad3 chore: initialize work on #59 Wildcard CORS Origin Allows Any Domain
<!-- /sharkrite-changes-summary -->