### PR TITLE
Apply rate limiting at stage level only

### DIFF
--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -346,7 +346,7 @@ class TestValidation:
     def test_validate_email_too_long(self):
         """Validation should fail when email exceeds 254 characters"""
         # Create email with 255 characters
-        local_part = 'a' * 240
+        local_part = 'a' * 243
         email = f'{local_part}@example.com'  # 255 total chars
         data = {
             'name': 'Test User',
@@ -360,7 +360,7 @@ class TestValidation:
     def test_validate_email_at_max_length(self):
         """Validation should pass when email is exactly 254 characters"""
         # Create email with 254 characters
-        local_part = 'a' * 239
+        local_part = 'a' * 242
         email = f'{local_part}@example.com'  # 254 total chars
         data = {
             'name': 'Test User',

--- a/backend/tests/test_rate_limit.py
+++ b/backend/tests/test_rate_limit.py
@@ -1,0 +1,89 @@
+import os
+import re
+import pytest
+
+
+class TestRateLimitConfiguration:
+    """Tests for API Gateway rate limiting configuration"""
+
+    @pytest.fixture
+    def sst_config_path(self):
+        """Path to sst.config.ts file"""
+        # Navigate up two levels from backend/tests/ to project root
+        project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
+        return os.path.join(project_root, 'sst.config.ts')
+
+    @pytest.fixture
+    def sst_config_content(self, sst_config_path):
+        """Read sst.config.ts file content"""
+        with open(sst_config_path, 'r') as f:
+            return f.read()
+
+    def test_rate_limiting_configured(self, sst_config_content):
+        """Verify API Gateway has throttling configured"""
+        # Check for throttlingRateLimit setting
+        assert 'throttlingRateLimit' in sst_config_content, \
+            "API Gateway throttlingRateLimit not found in sst.config.ts"
+
+        # Check for throttlingBurstLimit setting
+        assert 'throttlingBurstLimit' in sst_config_content, \
+            "API Gateway throttlingBurstLimit not found in sst.config.ts"
+
+    def test_rate_limit_values(self, sst_config_content):
+        """Verify rate limit values match requirements"""
+        # Extract throttlingRateLimit value
+        rate_match = re.search(r'throttlingRateLimit:\s*(\d+)', sst_config_content)
+        assert rate_match is not None, "throttlingRateLimit value not found"
+        rate_limit = int(rate_match.group(1))
+
+        # Extract throttlingBurstLimit value
+        burst_match = re.search(r'throttlingBurstLimit:\s*(\d+)', sst_config_content)
+        assert burst_match is not None, "throttlingBurstLimit value not found"
+        burst_limit = int(burst_match.group(1))
+
+        # Verify values match acceptance criteria
+        assert rate_limit == 100, \
+            f"Expected throttlingRateLimit=100, got {rate_limit}"
+        assert burst_limit == 200, \
+            f"Expected throttlingBurstLimit=200, got {burst_limit}"
+
+    def test_rate_limiting_on_api_gateway_v2(self, sst_config_content):
+        """Verify rate limiting is configured on ApiGatewayV2 (HTTP API)"""
+        # Ensure we're using ApiGatewayV2, not REST API
+        assert 'sst.aws.ApiGatewayV2' in sst_config_content, \
+            "Expected ApiGatewayV2 (HTTP API) in configuration"
+
+        # Verify throttling is in defaultRouteSettings
+        assert 'defaultRouteSettings' in sst_config_content, \
+            "defaultRouteSettings not found - throttling must be configured here for HTTP API"
+
+    def test_documentation_includes_limitations(self, sst_config_content):
+        """Verify documentation mentions HTTP API limitations"""
+        # Check for documentation about HTTP API limitations
+        # (HTTP API v2 doesn't support custom rate limit headers)
+        assert 'HTTP API' in sst_config_content or 'ApiGatewayV2' in sst_config_content, \
+            "Configuration should document API Gateway type"
+
+        # Check that stage-level throttling is documented
+        assert 'stage' in sst_config_content.lower(), \
+            "Configuration should document stage-level throttling"
+
+    def test_rate_limiting_protects_against_abuse(self, sst_config_content):
+        """Verify rate limiting is configured to prevent abuse"""
+        # Rate limit should be reasonable (not too high, not too low)
+        rate_match = re.search(r'throttlingRateLimit:\s*(\d+)', sst_config_content)
+        assert rate_match is not None
+        rate_limit = int(rate_match.group(1))
+
+        # Should be between 10 and 10000 requests/second
+        # Too low = legitimate users blocked, too high = doesn't prevent abuse
+        assert 10 <= rate_limit <= 10000, \
+            f"Rate limit {rate_limit} req/s seems unreasonable"
+
+        # Burst should be >= rate limit (allows traffic spikes)
+        burst_match = re.search(r'throttlingBurstLimit:\s*(\d+)', sst_config_content)
+        assert burst_match is not None
+        burst_limit = int(burst_match.group(1))
+
+        assert burst_limit >= rate_limit, \
+            f"Burst limit ({burst_limit}) should be >= rate limit ({rate_limit})"

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -114,10 +114,24 @@ export default $config({
         allowHeaders: ["Content-Type", "Authorization"],
       },
       transform: {
-        // Configure API Gateway throttling to prevent abuse
-        // Rate limit: 100 requests/second (aggregate across all users at stage level)
-        // Burst limit: 200 requests (handles short traffic spikes)
-        // When exceeded, API Gateway returns 429 Too Many Requests
+        // Configure API Gateway stage-level throttling to prevent abuse
+        //
+        // STAGE-LEVEL THROTTLING (Current Implementation):
+        // - Applies to ALL users collectively at the API stage
+        // - One bad actor CAN impact other users by exhausting the shared quota
+        // - Rate limit: 100 requests/second (aggregate across all users)
+        // - Burst limit: 200 requests (handles short traffic spikes)
+        // - Returns 429 Too Many Requests when limits exceeded
+        //
+        // LIMITATIONS (HTTP API v2):
+        // - Custom rate limit headers (X-RateLimit-*) are NOT supported
+        // - Would require REST API (v1) + Usage Plans for per-user limits
+        // - See issue #126 for per-user rate limiting discussion
+        //
+        // RATIONALE FOR LIMITS:
+        // - 100 req/s = 360K requests/hour, sufficient for small-medium apps
+        // - 200 burst = handles login spikes, batch operations
+        // - Conservative defaults prevent surprise AWS bills
         api: (args) => {
           args.defaultRouteSettings = {
             throttlingBurstLimit: 200,


### PR DESCRIPTION
## Work in Progress

Closes #126

Apply rate limiting at stage level only

<!-- sharkrite-source-issue:42 -->## From PR #124 Assessment

**Severity:** MEDIUM
**Category:** Security

## Issue
This is a valid security concern - stage-level rate limiting does allow one bad actor to impact all users. However, the original issue scope explicitly states "DO: Configure throttling at API Gateway level" and "DO NOT: Implement per-endpoint custom limits", indicating per-user limiting is intentionally out of scope. The current implementation fulfills the acceptance criteria.

## Context
The original issue explicitly scopes this to API Gateway-level throttling as a first step. Per-user rate limiting (via WAF, Lambda authorizer, or application-level) is a different architectural pattern requiring significant additional work beyond the 30min estimate.

## Defer Reason
Scope exceeds time budget - per-user rate limiting requires new architectural components (WAF rules or Lambda authorizer) not specified in original issue

---
_Created by Sharkrite assessment on 2026-04-04T23:56:10Z_
_Parent PR: #124_

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**3** files, **3** commits (+1 added, ~2 modified, -0 deleted)
- `M` backend/tests/test_config.py
- `A` backend/tests/test_rate_limit.py
- `M` sst.config.ts

### Commits
- 2450fa8 wip: auto-commit relevant changes for issue #126 (2026-04-17)
- 4f311cb Merge remote-tracking branch 'origin/main' into feat/apply-rate-limiting-at-stage-level-only
- 1517a61 chore: initialize work on #126 Apply rate limiting at stage level only
<!-- /sharkrite-changes-summary -->