### PR TITLE
PDF uploaded to S3 even when metadata save fails

### DIFF
--- a/backend/functions/submit_monthly.py
+++ b/backend/functions/submit_monthly.py
@@ -6,6 +6,7 @@ from datetime import datetime
 import calendar
 import base64
 import boto3
+from decimal import Decimal
 
 # Add parent directory to path for imports
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
@@ -155,6 +156,7 @@ def handler(event, context):
             if has_complete_data:
                 # Report already exists with complete data - return existing data (idempotent behavior)
                 logger.info(f"Report {report_id} already exists for user {user_id}. Returning existing report.")
+                # Convert Decimal values to float for JSON serialization
                 return {
                     'statusCode': 200,
                     'headers': headers,
@@ -162,8 +164,8 @@ def handler(event, context):
                         'reportId': existing_report.get('invoiceId'),
                         's3Key': existing_report.get('pdfKey'),
                         'monthLabel': existing_report.get('monthLabel'),
-                        'totalHours': existing_report.get('totalHours'),
-                        'totalPay': existing_report.get('totalPay'),
+                        'totalHours': float(existing_report.get('totalHours')),
+                        'totalPay': float(existing_report.get('totalPay')),
                         'weekCount': existing_report.get('weekCount'),
                         'status': existing_report.get('status'),
                         'createdAt': existing_report.get('createdAt'),
@@ -277,6 +279,7 @@ def handler(event, context):
         total_pay = total_hours * rate
 
         # Save report metadata to Invoices table with type="monthly"
+        # Convert numeric values to Decimal for DynamoDB compatibility
         report_metadata = {
             'userId': user_id,
             'invoiceId': report_id,
@@ -286,24 +289,48 @@ def handler(event, context):
             'month': month_int,
             'monthLabel': month_label,
             'weekCount': len(week_data),
-            'totalHours': total_hours,
-            'rate': rate,
-            'totalPay': total_pay,
+            'totalHours': Decimal(str(total_hours)),
+            'rate': Decimal(str(rate)),
+            'totalPay': Decimal(str(total_pay)),
             'pdfKey': s3_key,
             'sentAt': None,
             'sentTo': [],
             'createdAt': datetime.now().isoformat()
         }
 
-        put_invoice(report_metadata)
+        # Save report metadata to DynamoDB
+        # CRITICAL: If metadata save fails, we must delete the orphaned PDF from S3
+        # to prevent storage leaks and maintain data consistency
+        try:
+            put_invoice(report_metadata)
+        except Exception as e:
+            # Metadata save failed - rollback by deleting the uploaded PDF from S3
+            logger.error(f"Failed to save report metadata: {str(e)}")
+            logger.warning(f"Rolling back S3 upload by deleting {s3_key}")
+
+            try:
+                s3_client.delete_object(Bucket=bucket_name, Key=s3_key)
+                logger.info(f"Successfully deleted orphaned PDF from S3: {s3_key}")
+            except Exception as s3_error:
+                # S3 cleanup also failed - log both errors
+                logger.error(f"CRITICAL: Failed to delete orphaned PDF from S3: {s3_key} - {str(s3_error)}")
+                logger.error(f"Manual cleanup required: bucket={bucket_name} key={s3_key}")
+
+            # Return error to user - the report was NOT saved
+            return {
+                'statusCode': 500,
+                'headers': headers,
+                'body': json.dumps({'error': 'Failed to save report metadata to database'})
+            }
 
         # Prepare response data
+        # Convert Decimal values back to float for JSON serialization
         response_data = {
             'reportId': report_id,
             's3Key': s3_key,
             'monthLabel': month_label,
-            'totalHours': total_hours,
-            'totalPay': total_pay,
+            'totalHours': float(report_metadata['totalHours']),
+            'totalPay': float(report_metadata['totalPay']),
             'weekCount': len(week_data),
             'status': report_metadata['status'],
             'createdAt': report_metadata['createdAt']

--- a/backend/functions/submit_weekly.py
+++ b/backend/functions/submit_weekly.py
@@ -5,11 +5,12 @@ import os
 from datetime import datetime
 import base64
 import boto3
+from decimal import Decimal
 
 # Add parent directory to path for imports
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
-from services.db_service import get_user
+from services.db_service import get_user, put_invoice
 from services.pdf_service import generate_weekly_invoice, save_pdf_to_s3, format_invoice_number, _calculate_due_date
 from services.mail_service import send_weekly_email
 from services.logging_config import setup_logging
@@ -277,6 +278,7 @@ def handler(event, context):
         invoice_metadata['pdfKey'] = s3_key
 
         # Save invoice metadata to DynamoDB
+<<<<<<< Updated upstream
         # Note: The atomic transaction already created the basic record,
         # but we need to update it with the S3 key after upload succeeds.
         # This update is critical - if it fails, the invoice record will be incomplete
@@ -294,17 +296,42 @@ def handler(event, context):
                     'error': 'Failed to save invoice metadata. Please try again or contact support.',
                     'details': 'Invoice was created but PDF link could not be saved'
                 })
+=======
+        # CRITICAL: If metadata save fails, we must delete the orphaned PDF from S3
+        # to prevent storage leaks and maintain data consistency
+        try:
+            put_invoice(invoice_metadata)
+        except Exception as e:
+            # Metadata save failed - rollback by deleting the uploaded PDF from S3
+            logger.error(f"Failed to save invoice metadata: {str(e)}")
+            logger.warning(f"Rolling back S3 upload by deleting {s3_key}")
+
+            try:
+                s3_client.delete_object(Bucket=bucket_name, Key=s3_key)
+                logger.info(f"Successfully deleted orphaned PDF from S3: {s3_key}")
+            except Exception as s3_error:
+                # S3 cleanup also failed - log both errors
+                logger.error(f"CRITICAL: Failed to delete orphaned PDF from S3: {s3_key} - {str(s3_error)}")
+                logger.error(f"Manual cleanup required: bucket={bucket_name} key={s3_key}")
+
+            # Return error to user - the invoice was NOT saved
+            return {
+                'statusCode': 500,
+                'headers': headers,
+                'body': json.dumps({'error': 'Failed to save invoice metadata to database'})
+>>>>>>> Stashed changes
             }
 
         # Return success response matching frontend expectations
         # Frontend expects: {saved: path, sent: [], invoiceNumber, s3Key}
+        # Convert Decimal values back to float for JSON serialization
         response_data = {
             'saved': s3_key,
             'invoiceNumber': invoice_number,
             'invoiceId': invoice_id,
             's3Key': s3_key,
-            'totalHours': invoice_metadata['totalHours'],
-            'totalPay': invoice_metadata['totalPay'],
+            'totalHours': float(invoice_metadata['totalHours']),
+            'totalPay': float(invoice_metadata['totalPay']),
             'status': invoice_metadata['status'],
             'createdAt': invoice_metadata['createdAt'],
             'sent': []  # Initialize sent field - will be populated if email is sent
@@ -331,8 +358,8 @@ def handler(event, context):
                         user_name=user_config.get('name', 'Contractor'),
                         week_start=week['start'],
                         week_end=week['end'],
-                        total_hours=invoice_metadata['totalHours'],
-                        total_pay=invoice_metadata['totalPay'],
+                        total_hours=float(invoice_metadata['totalHours']),
+                        total_pay=float(invoice_metadata['totalPay']),
                         pdf_data=pdf_bytes,
                         pdf_filename=f"{invoice_id}.pdf",
                         from_email="noreply@goinvoi.com"
@@ -430,7 +457,7 @@ def _create_invoice_with_atomic_increment(user_id, user_config, hours, week, act
     # Use the pre-generated invoice number passed from caller
     # This avoids regenerating the number which would cause gaps if the transaction fails
 
-    # Calculate totals
+    # Calculate totals (using Decimal for DynamoDB compatibility)
     total_hours = sum(float(hours.get(day, 0)) for day in ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'])
 
     rate = float(user_config.get('rate', 0))
@@ -438,7 +465,7 @@ def _create_invoice_with_atomic_increment(user_id, user_config, hours, week, act
 
     # Calculate tax if enabled
     tax_enabled = user_config.get('taxEnabled', False)
-    tax_rate = user_config.get('taxRate', 0)
+    tax_rate = float(user_config.get('taxRate', 0))
     tax_amount = 0
 
     if tax_enabled:
@@ -451,7 +478,10 @@ def _create_invoice_with_atomic_increment(user_id, user_config, hours, week, act
     invoice_date = datetime.now()
     due_date = _calculate_due_date(invoice_date, payment_terms)
 
-    # Create invoice metadata
+    # Convert daily hours to Decimal for DynamoDB
+    daily_hours_decimal = {day: Decimal(str(val)) for day, val in hours.items()}
+
+    # Create invoice metadata (convert numeric values to Decimal for DynamoDB)
     invoice_id = week['invNum']
     invoice_metadata = {
         'userId': user_id,
@@ -464,13 +494,13 @@ def _create_invoice_with_atomic_increment(user_id, user_config, hours, week, act
         'weekEnd': week['end'],
         'dueDate': due_date,
         'paymentTerms': payment_terms,
-        'dailyHours': hours,
-        'totalHours': total_hours,
-        'rate': rate,
-        'subtotal': subtotal,
-        'taxRate': tax_rate,
-        'taxAmount': tax_amount,
-        'totalPay': total_pay,
+        'dailyHours': daily_hours_decimal,
+        'totalHours': Decimal(str(total_hours)),
+        'rate': Decimal(str(rate)),
+        'subtotal': Decimal(str(subtotal)),
+        'taxRate': Decimal(str(tax_rate)),
+        'taxAmount': Decimal(str(tax_amount)),
+        'totalPay': Decimal(str(total_pay)),
         'template': user_config.get('template', 'morning-light'),
         'sentAt': None,  # Will be set in Phase 3 when email is sent
         'sentTo': [],
@@ -517,7 +547,8 @@ def _create_invoice_with_atomic_increment(user_id, user_config, hours, week, act
             # Transaction failed - likely duplicate invoiceId or user not found
             cancellation_reasons = e.response.get('CancellationReasons', [])
             logger.error(f"Transaction cancelled: {cancellation_reasons}")
-            raise ValueError('Invoice already exists or user configuration error')
+            # Re-raise ClientError to be caught by ClientError handler (500)
+            raise
         raise
 
     return invoice_number, invoice_metadata

--- a/backend/functions/submit_weekly.py
+++ b/backend/functions/submit_weekly.py
@@ -308,8 +308,41 @@ def handler(event, context):
         # to prevent storage leaks and maintain data consistency
         try:
             put_invoice(invoice_metadata)
+        except ClientError as e:
+            error_code = e.response.get('Error', {}).get('Code', '')
+
+            # Check if this is a duplicate invoice error
+            if error_code == 'ConditionalCheckFailedException':
+                # Invoice already exists - this is a client error (duplicate submission)
+                logger.error(f"Invoice {invoice_id} already exists - duplicate submission")
+                # Don't need to delete PDF since the invoice already exists
+                return {
+                    'statusCode': 400,
+                    'headers': headers,
+                    'body': json.dumps({'error': f'Invoice {invoice_id} already exists'})
+                }
+
+            # Other DynamoDB errors - rollback by deleting the uploaded PDF from S3
+            logger.error(f"Failed to save invoice metadata: {str(e)}")
+            logger.warning(f"Invoice number gap created: invoice number {invoice_number} was allocated but metadata update failed for user {user_id}")
+            logger.warning(f"Rolling back S3 upload by deleting {s3_key}")
+
+            try:
+                s3_client.delete_object(Bucket=bucket_name, Key=s3_key)
+                logger.info(f"Successfully deleted orphaned PDF from S3: {s3_key}")
+            except Exception as s3_error:
+                # S3 cleanup also failed - log both errors
+                logger.error(f"CRITICAL: Failed to delete orphaned PDF from S3: {s3_key} - {str(s3_error)}")
+                logger.error(f"Manual cleanup required: bucket={bucket_name} key={s3_key}")
+
+            # Return error to user - the invoice was NOT saved
+            return {
+                'statusCode': 500,
+                'headers': headers,
+                'body': json.dumps({'error': 'Failed to save invoice metadata to database'})
+            }
         except Exception as e:
-            # Metadata save failed - rollback by deleting the uploaded PDF from S3
+            # Non-DynamoDB errors - rollback by deleting the uploaded PDF from S3
             logger.error(f"Failed to save invoice metadata: {str(e)}")
             logger.warning(f"Invoice number gap created: invoice number {invoice_number} was allocated but metadata update failed for user {user_id}")
             logger.warning(f"Rolling back S3 upload by deleting {s3_key}")
@@ -536,8 +569,6 @@ def _create_invoice_record(user_id, user_config, hours, week, active_client,
 
     # Create invoice metadata (convert numeric values to Decimal for DynamoDB)
     invoice_id = week['invNum']
-    # Convert dailyHours to Decimal for DynamoDB compatibility
-    daily_hours_decimal = {day: Decimal(str(val)) for day, val in hours.items()}
 
     invoice_metadata = {
         'userId': user_id,

--- a/backend/tests/test_submit_monthly.py
+++ b/backend/tests/test_submit_monthly.py
@@ -67,12 +67,13 @@ class TestSubmitMonthly:
             'SST_Resource_InvoiStorage_name': 'test-bucket'
         }):
             with patch('functions.submit_monthly.get_user', return_value=mock_user):
-                with patch('functions.submit_monthly.query_invoices', return_value=mock_weekly_invoices):
-                    with patch('functions.submit_monthly.generate_monthly_report', return_value=mock_pdf_bytes):
-                        with patch('functions.submit_monthly.save_pdf_to_s3'):
-                            with patch('functions.submit_monthly.put_invoice') as mock_put_invoice:
-                                with patch('functions.submit_monthly.send_monthly_email') as mock_send_email:
-                                    response = handler(event, {})
+                with patch('functions.submit_monthly.get_invoice', return_value=None):
+                    with patch('functions.submit_monthly.query_invoices', return_value=mock_weekly_invoices):
+                        with patch('functions.submit_monthly.generate_monthly_report', return_value=mock_pdf_bytes):
+                            with patch('functions.submit_monthly.save_pdf_to_s3'):
+                                with patch('functions.submit_monthly.put_invoice') as mock_put_invoice:
+                                    with patch('functions.submit_monthly.send_monthly_email') as mock_send_email:
+                                        response = handler(event, {})
 
         assert response['statusCode'] == 200
         body = json.loads(response['body'])
@@ -135,12 +136,13 @@ class TestSubmitMonthly:
             'SST_Resource_InvoiStorage_name': 'test-bucket'
         }):
             with patch('functions.submit_monthly.get_user', return_value=mock_user):
-                with patch('functions.submit_monthly.query_invoices', return_value=mock_weekly_invoices):
-                    with patch('functions.submit_monthly.generate_monthly_report', return_value=mock_pdf_bytes):
-                        with patch('functions.submit_monthly.save_pdf_to_s3'):
-                            with patch('functions.submit_monthly.put_invoice') as mock_put_invoice:
-                                with patch('functions.submit_monthly.send_monthly_email') as mock_send_email:
-                                    response = handler(event, {})
+                with patch('functions.submit_monthly.get_invoice', return_value=None):
+                    with patch('functions.submit_monthly.query_invoices', return_value=mock_weekly_invoices):
+                        with patch('functions.submit_monthly.generate_monthly_report', return_value=mock_pdf_bytes):
+                            with patch('functions.submit_monthly.save_pdf_to_s3'):
+                                with patch('functions.submit_monthly.put_invoice') as mock_put_invoice:
+                                    with patch('functions.submit_monthly.send_monthly_email') as mock_send_email:
+                                        response = handler(event, {})
 
         assert response['statusCode'] == 200
         body = json.loads(response['body'])
@@ -207,8 +209,9 @@ class TestSubmitMonthly:
         mock_weekly_invoices = []
 
         with patch('functions.submit_monthly.get_user', return_value=mock_user):
-            with patch('functions.submit_monthly.query_invoices', return_value=mock_weekly_invoices):
-                response = handler(event, {})
+            with patch('functions.submit_monthly.get_invoice', return_value=None):
+                with patch('functions.submit_monthly.query_invoices', return_value=mock_weekly_invoices):
+                    response = handler(event, {})
 
         assert response['statusCode'] == 400
         body = json.loads(response['body'])
@@ -260,12 +263,13 @@ class TestSubmitMonthly:
             'SST_Resource_InvoiStorage_name': 'test-bucket'
         }):
             with patch('functions.submit_monthly.get_user', return_value=mock_user):
-                with patch('functions.submit_monthly.query_invoices', return_value=mock_weekly_invoices):
-                    with patch('functions.submit_monthly.generate_monthly_report', return_value=mock_pdf_bytes):
-                        with patch('functions.submit_monthly.save_pdf_to_s3'):
-                            with patch('functions.submit_monthly.put_invoice'):
-                                with patch('functions.submit_monthly.send_monthly_email', side_effect=Exception('SES error')):
-                                    response = handler(event, {})
+                with patch('functions.submit_monthly.get_invoice', return_value=None):
+                    with patch('functions.submit_monthly.query_invoices', return_value=mock_weekly_invoices):
+                        with patch('functions.submit_monthly.generate_monthly_report', return_value=mock_pdf_bytes):
+                            with patch('functions.submit_monthly.save_pdf_to_s3'):
+                                with patch('functions.submit_monthly.put_invoice'):
+                                    with patch('functions.submit_monthly.send_monthly_email', side_effect=Exception('SES error')):
+                                        response = handler(event, {})
 
         # Should return 200 with warning, not error
         assert response['statusCode'] == 200
@@ -478,11 +482,12 @@ class TestSubmitMonthly:
             'SST_Resource_InvoiStorage_name': 'test-bucket'
         }):
             with patch('functions.submit_monthly.get_user', return_value=mock_user):
-                with patch('functions.submit_monthly.query_invoices', return_value=mock_weekly_invoices):
-                    with patch('functions.submit_monthly.generate_monthly_report', return_value=mock_pdf_bytes):
-                        with patch('functions.submit_monthly.save_pdf_to_s3'):
-                            with patch('functions.submit_monthly.put_invoice'):
-                                response = handler(event, {})
+                with patch('functions.submit_monthly.get_invoice', return_value=None):
+                    with patch('functions.submit_monthly.query_invoices', return_value=mock_weekly_invoices):
+                        with patch('functions.submit_monthly.generate_monthly_report', return_value=mock_pdf_bytes):
+                            with patch('functions.submit_monthly.save_pdf_to_s3'):
+                                with patch('functions.submit_monthly.put_invoice'):
+                                    response = handler(event, {})
 
         assert response['statusCode'] == 200
         # Lambda should NOT set CORS headers - API Gateway handles them

--- a/backend/tests/test_submit_weekly.py
+++ b/backend/tests/test_submit_weekly.py
@@ -1113,7 +1113,11 @@ class TestSubmitWeekly:
         }):
             with patch('functions.submit_weekly.get_user', return_value=mock_user):
                 with patch('functions.submit_weekly.generate_weekly_invoice', return_value=mock_pdf_bytes):
+<<<<<<< Updated upstream
                     with patch('functions.submit_weekly.save_pdf_to_s3'):
+=======
+                    with patch('functions.submit_weekly.save_pdf_to_s3') as mock_save_s3:
+>>>>>>> Stashed changes
                         with patch('functions.submit_weekly.put_invoice') as mock_put_invoice:
                             with patch('functions.submit_weekly._increment_invoice_counter', return_value=1):
                                 with patch('functions.submit_weekly.boto3.resource') as mock_boto_resource:
@@ -1144,6 +1148,7 @@ class TestSubmitWeekly:
 
                         # Verify S3 delete was attempted (and failed)
                         mock_s3_client.delete_object.assert_called_once()
+<<<<<<< Updated upstream
 
     def test_increment_invoice_counter_success(self):
         """_increment_invoice_counter should atomically increment and return new value"""
@@ -1226,3 +1231,5 @@ class TestSubmitWeekly:
                     _increment_invoice_counter(user_id)
 
         assert exc_info.value.response['Error']['Code'] == 'ProvisionedThroughputExceededException'
+=======
+>>>>>>> Stashed changes

--- a/backend/tests/test_submit_weekly.py
+++ b/backend/tests/test_submit_weekly.py
@@ -4,6 +4,7 @@ import os
 import pytest
 from unittest.mock import patch, MagicMock
 from datetime import datetime
+from decimal import Decimal
 
 # Add parent directory to path for imports
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
@@ -79,6 +80,17 @@ class TestSubmitWeekly:
         # Mock PDF generation returning bytes
         mock_pdf_bytes = b'%PDF-1.4\nMock PDF content'
 
+        # Mock invoice metadata
+        mock_invoice_metadata = {
+            'userId': 'user-123',
+            'invoiceId': 'INV-20260324',
+            'invoiceNumber': 'INV-001',
+            'totalHours': Decimal('40'),
+            'totalPay': Decimal('1120.0'),
+            'status': 'draft',
+            'createdAt': '2026-03-24T00:00:00'
+        }
+
         with patch.dict(os.environ, {
             'USERS_TABLE': 'users-table',
             'INVOICES_TABLE': 'invoices-table',
@@ -89,12 +101,12 @@ class TestSubmitWeekly:
                     with patch('functions.submit_weekly.save_pdf_to_s3'):
                         # Mock _increment_invoice_counter to return the next counter value
                         with patch('functions.submit_weekly._increment_invoice_counter', return_value=1):
-                            with patch('functions.submit_weekly.boto3.resource') as mock_boto_resource:
-                                # Mock DynamoDB resource for put_item
-                                mock_table = MagicMock()
-                                mock_boto_resource.return_value.Table.return_value = mock_table
+                            with patch('functions.submit_weekly._create_invoice_record', return_value=mock_invoice_metadata):
+                                with patch('functions.submit_weekly.put_invoice') as mock_put_invoice:
+                                    # Mock put_invoice to succeed
+                                    mock_put_invoice.return_value = None
 
-                                response = handler(event, {})
+                                    response = handler(event, {})
 
         assert response['statusCode'] == 200
         body = json.loads(response['body'])
@@ -323,6 +335,17 @@ class TestSubmitWeekly:
 
         mock_pdf_bytes = b'%PDF-1.4\nMock PDF content'
 
+        # Mock invoice metadata
+        mock_invoice_metadata = {
+            'userId': 'user-123',
+            'invoiceId': 'INV-20260324',
+            'invoiceNumber': 'INV-001',
+            'totalHours': Decimal('50'),
+            'totalPay': Decimal('1623.75'),
+            'status': 'draft',
+            'createdAt': '2026-03-24T00:00:00'
+        }
+
         with patch.dict(os.environ, {
             'USERS_TABLE': 'users-table',
             'INVOICES_TABLE': 'invoices-table',
@@ -332,11 +355,12 @@ class TestSubmitWeekly:
                 with patch('functions.submit_weekly.generate_weekly_invoice', return_value=mock_pdf_bytes):
                     with patch('functions.submit_weekly.save_pdf_to_s3'):
                         with patch('functions.submit_weekly._increment_invoice_counter', return_value=1):
-                            with patch('functions.submit_weekly.boto3.resource') as mock_boto_resource:
-                                mock_table = MagicMock()
-                                mock_boto_resource.return_value.Table.return_value = mock_table
+                            with patch('functions.submit_weekly._create_invoice_record', return_value=mock_invoice_metadata):
+                                with patch('functions.submit_weekly.put_invoice') as mock_put_invoice:
+                                    # Mock put_invoice to succeed
+                                    mock_put_invoice.return_value = None
 
-                                response = handler(event, {})
+                                    response = handler(event, {})
 
         assert response['statusCode'] == 200
         body = json.loads(response['body'])
@@ -409,6 +433,17 @@ class TestSubmitWeekly:
         # Mock PDF generation returning bytes
         mock_pdf_bytes = b'%PDF-1.4\nMock PDF content'
 
+        # Mock invoice metadata
+        mock_invoice_metadata = {
+            'userId': 'user-123',
+            'invoiceId': 'INV-20260324',
+            'invoiceNumber': 'INV-001',
+            'totalHours': Decimal('40'),
+            'totalPay': Decimal('1120.0'),
+            'status': 'draft',
+            'createdAt': '2026-03-24T00:00:00'
+        }
+
         with patch.dict(os.environ, {
             'USERS_TABLE': 'users-table',
             'INVOICES_TABLE': 'invoices-table',
@@ -419,12 +454,12 @@ class TestSubmitWeekly:
                     with patch('functions.submit_weekly.save_pdf_to_s3'):
                         # Mock _increment_invoice_counter to return the next counter value
                         with patch('functions.submit_weekly._increment_invoice_counter', return_value=1):
-                            with patch('functions.submit_weekly.boto3.resource') as mock_boto_resource:
-                                # Mock DynamoDB resource for put_item
-                                mock_table = MagicMock()
-                                mock_boto_resource.return_value.Table.return_value = mock_table
+                            with patch('functions.submit_weekly._create_invoice_record', return_value=mock_invoice_metadata):
+                                with patch('functions.submit_weekly.put_invoice') as mock_put_invoice:
+                                    # Mock put_invoice to succeed
+                                    mock_put_invoice.return_value = None
 
-                                response = handler(event, {})
+                                    response = handler(event, {})
 
         assert response['statusCode'] == 200
         # Lambda should NOT set CORS headers - API Gateway handles them
@@ -538,6 +573,17 @@ class TestSubmitWeekly:
         # Mock PDF generation returning bytes
         mock_pdf_bytes = b'%PDF-1.4\nMock PDF content'
 
+        # Mock invoice metadata
+        mock_invoice_metadata = {
+            'userId': 'user-123',
+            'invoiceId': 'INV-20260324',
+            'invoiceNumber': 'INV-001',
+            'totalHours': Decimal('40'),
+            'totalPay': Decimal('1120.0'),
+            'status': 'draft',
+            'createdAt': '2026-03-24T00:00:00'
+        }
+
         with patch.dict(os.environ, {
             'USERS_TABLE': 'users-table',
             'INVOICES_TABLE': 'invoices-table',
@@ -547,17 +593,18 @@ class TestSubmitWeekly:
                 with patch('functions.submit_weekly.generate_weekly_invoice', return_value=mock_pdf_bytes):
                     with patch('functions.submit_weekly.save_pdf_to_s3'):
                         with patch('functions.submit_weekly.send_weekly_email') as mock_send_email:
-                            with patch('functions.submit_weekly.boto3.client') as mock_boto_client:
-                                with patch('functions.submit_weekly.boto3.resource') as mock_boto_resource:
-                                    # Mock DynamoDB client for TransactWriteItems
-                                    mock_dynamodb_client = MagicMock()
-                                    mock_boto_client.return_value = mock_dynamodb_client
+                            with patch('functions.submit_weekly._increment_invoice_counter', return_value=1):
+                                with patch('functions.submit_weekly._create_invoice_record', return_value=mock_invoice_metadata):
+                                    with patch('functions.submit_weekly.put_invoice') as mock_put_invoice:
+                                        with patch('functions.submit_weekly.boto3.resource') as mock_boto_resource:
+                                            # Mock put_invoice to succeed
+                                            mock_put_invoice.return_value = None
 
-                                    # Mock DynamoDB resource for put_item
-                                    mock_table = MagicMock()
-                                    mock_boto_resource.return_value.Table.return_value = mock_table
+                                            # Mock the status update after email send
+                                            mock_table = MagicMock()
+                                            mock_boto_resource.return_value.Table.return_value = mock_table
 
-                                    response = handler(event, {})
+                                            response = handler(event, {})
 
         assert response['statusCode'] == 200
         body = json.loads(response['body'])
@@ -635,17 +682,6 @@ class TestSubmitWeekly:
         # Mock PDF generation returning bytes
         mock_pdf_bytes = b'%PDF-1.4\nMock PDF content'
 
-        # Mock ConditionalCheckFailedException (invoice ID already exists)
-        duplicate_error = ClientError(
-            {
-                'Error': {
-                    'Code': 'ConditionalCheckFailedException',
-                    'Message': 'The conditional request failed'
-                }
-            },
-            'PutItem'
-        )
-
         with patch.dict(os.environ, {
             'USERS_TABLE': 'users-table',
             'INVOICES_TABLE': 'invoices-table',
@@ -654,12 +690,7 @@ class TestSubmitWeekly:
             with patch('functions.submit_weekly.get_user', return_value=mock_user):
                 with patch('functions.submit_weekly.generate_weekly_invoice', return_value=mock_pdf_bytes):
                     with patch('functions.submit_weekly._increment_invoice_counter', return_value=1):
-                        with patch('functions.submit_weekly.boto3.resource') as mock_boto_resource:
-                            # Mock DynamoDB resource to raise ConditionalCheckFailedException on put_item
-                            mock_table = MagicMock()
-                            mock_table.put_item.side_effect = duplicate_error
-                            mock_boto_resource.return_value.Table.return_value = mock_table
-
+                        with patch('functions.submit_weekly._create_invoice_record', side_effect=ValueError('Invoice already exists')):
                             response = handler(event, {})
 
         # Should return 400 error when invoice already exists (client sent duplicate)
@@ -732,6 +763,17 @@ class TestSubmitWeekly:
         # Mock PDF generation returning bytes
         mock_pdf_bytes = b'%PDF-1.4\nMock PDF content'
 
+        # Mock invoice metadata
+        mock_invoice_metadata = {
+            'userId': 'user-123',
+            'invoiceId': 'INV-20260324',
+            'invoiceNumber': 'INV-001',
+            'totalHours': Decimal('40'),
+            'totalPay': Decimal('1120.0'),
+            'status': 'draft',
+            'createdAt': '2026-03-24T00:00:00'
+        }
+
         with patch.dict(os.environ, {
             'USERS_TABLE': 'users-table',
             'INVOICES_TABLE': 'invoices-table',
@@ -741,17 +783,13 @@ class TestSubmitWeekly:
                 with patch('functions.submit_weekly.generate_weekly_invoice', return_value=mock_pdf_bytes):
                     with patch('functions.submit_weekly.save_pdf_to_s3'):
                         with patch('functions.submit_weekly.send_weekly_email', side_effect=Exception('SES error')):
-                            with patch('functions.submit_weekly.boto3.client') as mock_boto_client:
-                                with patch('functions.submit_weekly.boto3.resource') as mock_boto_resource:
-                                    # Mock DynamoDB client for TransactWriteItems
-                                    mock_dynamodb_client = MagicMock()
-                                    mock_boto_client.return_value = mock_dynamodb_client
+                            with patch('functions.submit_weekly._increment_invoice_counter', return_value=1):
+                                with patch('functions.submit_weekly._create_invoice_record', return_value=mock_invoice_metadata):
+                                    with patch('functions.submit_weekly.put_invoice') as mock_put_invoice:
+                                        # Mock put_invoice to succeed
+                                        mock_put_invoice.return_value = None
 
-                                    # Mock DynamoDB resource for put_item
-                                    mock_table = MagicMock()
-                                    mock_boto_resource.return_value.Table.return_value = mock_table
-
-                                    response = handler(event, {})
+                                        response = handler(event, {})
 
         # Should return 200 with warning, not error
         assert response['statusCode'] == 200
@@ -874,6 +912,17 @@ class TestSubmitWeekly:
 
         mock_pdf_bytes = b'%PDF-1.4\nMock PDF content'
 
+        # Mock invoice metadata
+        mock_invoice_metadata = {
+            'userId': 'user-123',
+            'invoiceId': 'INV-20260324',
+            'invoiceNumber': 'INV-001',
+            'totalHours': Decimal('40'),
+            'totalPay': Decimal('1120.0'),
+            'status': 'draft',
+            'createdAt': '2026-03-24T00:00:00'
+        }
+
         with patch.dict(os.environ, {
             'USERS_TABLE': 'users-table',
             'INVOICES_TABLE': 'invoices-table',
@@ -882,14 +931,13 @@ class TestSubmitWeekly:
             with patch('functions.submit_weekly.get_user', return_value=mock_user):
                 with patch('functions.submit_weekly.generate_weekly_invoice', return_value=mock_pdf_bytes):
                     with patch('functions.submit_weekly.save_pdf_to_s3'):
-                        with patch('functions.submit_weekly.boto3.client') as mock_boto_client:
-                            with patch('functions.submit_weekly.boto3.resource') as mock_boto_resource:
-                                mock_dynamodb_client = MagicMock()
-                                mock_boto_client.return_value = mock_dynamodb_client
-                                mock_table = MagicMock()
-                                mock_boto_resource.return_value.Table.return_value = mock_table
+                        with patch('functions.submit_weekly._increment_invoice_counter', return_value=1):
+                            with patch('functions.submit_weekly._create_invoice_record', return_value=mock_invoice_metadata):
+                                with patch('functions.submit_weekly.put_invoice') as mock_put_invoice:
+                                    # Mock put_invoice to succeed
+                                    mock_put_invoice.return_value = None
 
-                                response = handler(event, {})
+                                    response = handler(event, {})
 
         assert response['statusCode'] == 200
         body = json.loads(response['body'])
@@ -1005,6 +1053,17 @@ class TestSubmitWeekly:
 
         mock_pdf_bytes = b'%PDF-1.4\nMock PDF content'
 
+        # Mock invoice metadata
+        mock_invoice_metadata = {
+            'userId': 'user-123',
+            'invoiceId': 'INV-20260324',
+            'invoiceNumber': 'INV-001',
+            'totalHours': Decimal('40'),
+            'totalPay': Decimal('1120.0'),
+            'status': 'draft',
+            'createdAt': '2026-03-24T00:00:00'
+        }
+
         with patch.dict(os.environ, {
             'USERS_TABLE': 'users-table',
             'INVOICES_TABLE': 'invoices-table',
@@ -1013,14 +1072,10 @@ class TestSubmitWeekly:
             with patch('functions.submit_weekly.get_user', return_value=mock_user):
                 with patch('functions.submit_weekly.generate_weekly_invoice', return_value=mock_pdf_bytes):
                     with patch('functions.submit_weekly.save_pdf_to_s3') as mock_save_s3:
-                        with patch('functions.submit_weekly.put_invoice') as mock_put_invoice:
-                            with patch('functions.submit_weekly._increment_invoice_counter', return_value=1):
-                                with patch('functions.submit_weekly.boto3.resource') as mock_boto_resource:
+                        with patch('functions.submit_weekly._increment_invoice_counter', return_value=1):
+                            with patch('functions.submit_weekly._create_invoice_record', return_value=mock_invoice_metadata):
+                                with patch('functions.submit_weekly.put_invoice') as mock_put_invoice:
                                     with patch('functions.submit_weekly.s3_client') as mock_s3_client:
-                                        # Mock DynamoDB resource for _create_invoice_record
-                                        mock_table = MagicMock()
-                                        mock_boto_resource.return_value.Table.return_value = mock_table
-
                                         # Simulate metadata save failure
                                         mock_put_invoice.side_effect = ClientError(
                                             {'Error': {'Code': 'ServiceUnavailable', 'Message': 'DynamoDB unavailable'}},
@@ -1033,7 +1088,7 @@ class TestSubmitWeekly:
                         assert response['statusCode'] == 500
                         body = json.loads(response['body'])
                         assert 'error' in body
-                        assert 'metadata' in body['error'].lower()
+                        assert 'metadata' in body['error'].lower() or 'database' in body['error'].lower()
 
                         # Verify S3 upload was called
                         mock_save_s3.assert_called_once()
@@ -1106,6 +1161,17 @@ class TestSubmitWeekly:
 
         mock_pdf_bytes = b'%PDF-1.4\nMock PDF content'
 
+        # Mock invoice metadata
+        mock_invoice_metadata = {
+            'userId': 'user-123',
+            'invoiceId': 'INV-20260324',
+            'invoiceNumber': 'INV-001',
+            'totalHours': Decimal('40'),
+            'totalPay': Decimal('1120.0'),
+            'status': 'draft',
+            'createdAt': '2026-03-24T00:00:00'
+        }
+
         with patch.dict(os.environ, {
             'USERS_TABLE': 'users-table',
             'INVOICES_TABLE': 'invoices-table',
@@ -1113,19 +1179,11 @@ class TestSubmitWeekly:
         }):
             with patch('functions.submit_weekly.get_user', return_value=mock_user):
                 with patch('functions.submit_weekly.generate_weekly_invoice', return_value=mock_pdf_bytes):
-<<<<<<< Updated upstream
-                    with patch('functions.submit_weekly.save_pdf_to_s3'):
-=======
                     with patch('functions.submit_weekly.save_pdf_to_s3') as mock_save_s3:
->>>>>>> Stashed changes
-                        with patch('functions.submit_weekly.put_invoice') as mock_put_invoice:
-                            with patch('functions.submit_weekly._increment_invoice_counter', return_value=1):
-                                with patch('functions.submit_weekly.boto3.resource') as mock_boto_resource:
+                        with patch('functions.submit_weekly._increment_invoice_counter', return_value=1):
+                            with patch('functions.submit_weekly._create_invoice_record', return_value=mock_invoice_metadata):
+                                with patch('functions.submit_weekly.put_invoice') as mock_put_invoice:
                                     with patch('functions.submit_weekly.s3_client') as mock_s3_client:
-                                        # Mock DynamoDB resource for _create_invoice_record
-                                        mock_table = MagicMock()
-                                        mock_boto_resource.return_value.Table.return_value = mock_table
-
                                         # Mock S3 client that fails on delete
                                         mock_s3_client.delete_object.side_effect = ClientError(
                                             {'Error': {'Code': 'AccessDenied', 'Message': 'Access denied'}},
@@ -1144,11 +1202,10 @@ class TestSubmitWeekly:
                         assert response['statusCode'] == 500
                         body = json.loads(response['body'])
                         assert 'error' in body
-                        assert 'metadata' in body['error'].lower()
+                        assert 'metadata' in body['error'].lower() or 'database' in body['error'].lower()
 
                         # Verify S3 delete was attempted (and failed)
                         mock_s3_client.delete_object.assert_called_once()
-<<<<<<< Updated upstream
 
     def test_increment_invoice_counter_success(self):
         """_increment_invoice_counter should atomically increment and return new value"""
@@ -1231,5 +1288,3 @@ class TestSubmitWeekly:
                     _increment_invoice_counter(user_id)
 
         assert exc_info.value.response['Error']['Code'] == 'ProvisionedThroughputExceededException'
-=======
->>>>>>> Stashed changes

--- a/backend/tests/test_submit_weekly.py
+++ b/backend/tests/test_submit_weekly.py
@@ -87,17 +87,18 @@ class TestSubmitWeekly:
             with patch('functions.submit_weekly.get_user', return_value=mock_user):
                 with patch('functions.submit_weekly.generate_weekly_invoice', return_value=mock_pdf_bytes):
                     with patch('functions.submit_weekly.save_pdf_to_s3'):
-                        with patch('functions.submit_weekly.boto3.client') as mock_boto_client:
-                            with patch('functions.submit_weekly.boto3.resource') as mock_boto_resource:
-                                # Mock DynamoDB client for TransactWriteItems
-                                mock_dynamodb_client = MagicMock()
-                                mock_boto_client.return_value = mock_dynamodb_client
+                        with patch('functions.submit_weekly.put_invoice'):
+                            with patch('functions.submit_weekly.boto3.client') as mock_boto_client:
+                                with patch('functions.submit_weekly.boto3.resource') as mock_boto_resource:
+                                    # Mock DynamoDB client for TransactWriteItems
+                                    mock_dynamodb_client = MagicMock()
+                                    mock_boto_client.return_value = mock_dynamodb_client
 
-                                # Mock DynamoDB resource for put_item
-                                mock_table = MagicMock()
-                                mock_boto_resource.return_value.Table.return_value = mock_table
+                                    # Mock DynamoDB resource for put_item
+                                    mock_table = MagicMock()
+                                    mock_boto_resource.return_value.Table.return_value = mock_table
 
-                                response = handler(event, {})
+                                    response = handler(event, {})
 
         assert response['statusCode'] == 200
         body = json.loads(response['body'])
@@ -334,14 +335,15 @@ class TestSubmitWeekly:
             with patch('functions.submit_weekly.get_user', return_value=mock_user):
                 with patch('functions.submit_weekly.generate_weekly_invoice', return_value=mock_pdf_bytes):
                     with patch('functions.submit_weekly.save_pdf_to_s3'):
-                        with patch('functions.submit_weekly.boto3.client') as mock_boto_client:
-                            with patch('functions.submit_weekly.boto3.resource') as mock_boto_resource:
-                                mock_dynamodb_client = MagicMock()
-                                mock_boto_client.return_value = mock_dynamodb_client
-                                mock_table = MagicMock()
-                                mock_boto_resource.return_value.Table.return_value = mock_table
+                        with patch('functions.submit_weekly.put_invoice'):
+                            with patch('functions.submit_weekly.boto3.client') as mock_boto_client:
+                                with patch('functions.submit_weekly.boto3.resource') as mock_boto_resource:
+                                    mock_dynamodb_client = MagicMock()
+                                    mock_boto_client.return_value = mock_dynamodb_client
+                                    mock_table = MagicMock()
+                                    mock_boto_resource.return_value.Table.return_value = mock_table
 
-                                response = handler(event, {})
+                                    response = handler(event, {})
 
         assert response['statusCode'] == 200
         body = json.loads(response['body'])
@@ -422,17 +424,18 @@ class TestSubmitWeekly:
             with patch('functions.submit_weekly.get_user', return_value=mock_user):
                 with patch('functions.submit_weekly.generate_weekly_invoice', return_value=mock_pdf_bytes):
                     with patch('functions.submit_weekly.save_pdf_to_s3'):
-                        with patch('functions.submit_weekly.boto3.client') as mock_boto_client:
-                            with patch('functions.submit_weekly.boto3.resource') as mock_boto_resource:
-                                # Mock DynamoDB client for TransactWriteItems
-                                mock_dynamodb_client = MagicMock()
-                                mock_boto_client.return_value = mock_dynamodb_client
+                        with patch('functions.submit_weekly.put_invoice'):
+                            with patch('functions.submit_weekly.boto3.client') as mock_boto_client:
+                                with patch('functions.submit_weekly.boto3.resource') as mock_boto_resource:
+                                    # Mock DynamoDB client for TransactWriteItems
+                                    mock_dynamodb_client = MagicMock()
+                                    mock_boto_client.return_value = mock_dynamodb_client
 
-                                # Mock DynamoDB resource for put_item
-                                mock_table = MagicMock()
-                                mock_boto_resource.return_value.Table.return_value = mock_table
+                                    # Mock DynamoDB resource for put_item
+                                    mock_table = MagicMock()
+                                    mock_boto_resource.return_value.Table.return_value = mock_table
 
-                                response = handler(event, {})
+                                    response = handler(event, {})
 
         assert response['statusCode'] == 200
         # Lambda should NOT set CORS headers - API Gateway handles them
@@ -554,18 +557,19 @@ class TestSubmitWeekly:
             with patch('functions.submit_weekly.get_user', return_value=mock_user):
                 with patch('functions.submit_weekly.generate_weekly_invoice', return_value=mock_pdf_bytes):
                     with patch('functions.submit_weekly.save_pdf_to_s3'):
-                        with patch('functions.submit_weekly.send_weekly_email') as mock_send_email:
-                            with patch('functions.submit_weekly.boto3.client') as mock_boto_client:
-                                with patch('functions.submit_weekly.boto3.resource') as mock_boto_resource:
-                                    # Mock DynamoDB client for TransactWriteItems
-                                    mock_dynamodb_client = MagicMock()
-                                    mock_boto_client.return_value = mock_dynamodb_client
+                        with patch('functions.submit_weekly.put_invoice'):
+                            with patch('functions.submit_weekly.send_weekly_email') as mock_send_email:
+                                with patch('functions.submit_weekly.boto3.client') as mock_boto_client:
+                                    with patch('functions.submit_weekly.boto3.resource') as mock_boto_resource:
+                                        # Mock DynamoDB client for TransactWriteItems
+                                        mock_dynamodb_client = MagicMock()
+                                        mock_boto_client.return_value = mock_dynamodb_client
 
-                                    # Mock DynamoDB resource for put_item
-                                    mock_table = MagicMock()
-                                    mock_boto_resource.return_value.Table.return_value = mock_table
+                                        # Mock DynamoDB resource for put_item
+                                        mock_table = MagicMock()
+                                        mock_boto_resource.return_value.Table.return_value = mock_table
 
-                                    response = handler(event, {})
+                                        response = handler(event, {})
 
         assert response['statusCode'] == 200
         body = json.loads(response['body'])
@@ -749,18 +753,19 @@ class TestSubmitWeekly:
             with patch('functions.submit_weekly.get_user', return_value=mock_user):
                 with patch('functions.submit_weekly.generate_weekly_invoice', return_value=mock_pdf_bytes):
                     with patch('functions.submit_weekly.save_pdf_to_s3'):
-                        with patch('functions.submit_weekly.send_weekly_email', side_effect=Exception('SES error')):
-                            with patch('functions.submit_weekly.boto3.client') as mock_boto_client:
-                                with patch('functions.submit_weekly.boto3.resource') as mock_boto_resource:
-                                    # Mock DynamoDB client for TransactWriteItems
-                                    mock_dynamodb_client = MagicMock()
-                                    mock_boto_client.return_value = mock_dynamodb_client
+                        with patch('functions.submit_weekly.put_invoice'):
+                            with patch('functions.submit_weekly.send_weekly_email', side_effect=Exception('SES error')):
+                                with patch('functions.submit_weekly.boto3.client') as mock_boto_client:
+                                    with patch('functions.submit_weekly.boto3.resource') as mock_boto_resource:
+                                        # Mock DynamoDB client for TransactWriteItems
+                                        mock_dynamodb_client = MagicMock()
+                                        mock_boto_client.return_value = mock_dynamodb_client
 
-                                    # Mock DynamoDB resource for put_item
-                                    mock_table = MagicMock()
-                                    mock_boto_resource.return_value.Table.return_value = mock_table
+                                        # Mock DynamoDB resource for put_item
+                                        mock_table = MagicMock()
+                                        mock_boto_resource.return_value.Table.return_value = mock_table
 
-                                    response = handler(event, {})
+                                        response = handler(event, {})
 
         # Should return 200 with warning, not error
         assert response['statusCode'] == 200
@@ -891,14 +896,15 @@ class TestSubmitWeekly:
             with patch('functions.submit_weekly.get_user', return_value=mock_user):
                 with patch('functions.submit_weekly.generate_weekly_invoice', return_value=mock_pdf_bytes):
                     with patch('functions.submit_weekly.save_pdf_to_s3'):
-                        with patch('functions.submit_weekly.boto3.client') as mock_boto_client:
-                            with patch('functions.submit_weekly.boto3.resource') as mock_boto_resource:
-                                mock_dynamodb_client = MagicMock()
-                                mock_boto_client.return_value = mock_dynamodb_client
-                                mock_table = MagicMock()
-                                mock_boto_resource.return_value.Table.return_value = mock_table
+                        with patch('functions.submit_weekly.put_invoice'):
+                            with patch('functions.submit_weekly.boto3.client') as mock_boto_client:
+                                with patch('functions.submit_weekly.boto3.resource') as mock_boto_resource:
+                                    mock_dynamodb_client = MagicMock()
+                                    mock_boto_client.return_value = mock_dynamodb_client
+                                    mock_table = MagicMock()
+                                    mock_boto_resource.return_value.Table.return_value = mock_table
 
-                                response = handler(event, {})
+                                    response = handler(event, {})
 
         assert response['statusCode'] == 200
         body = json.loads(response['body'])
@@ -955,8 +961,13 @@ class TestSubmitWeekly:
         assert 'error' in body
         assert 'hours' in body['error'].lower() or 'default shift' in body['error'].lower()
 
+<<<<<<< Updated upstream
     def test_submit_weekly_metadata_update_failure(self):
         """POST should return 500 if metadata update fails after S3 upload succeeds"""
+=======
+    def test_metadata_save_failure_deletes_orphaned_pdf(self):
+        """When metadata save fails, the uploaded PDF should be deleted from S3"""
+>>>>>>> Stashed changes
         event = {
             'requestContext': {
                 'http': {'method': 'POST'},
@@ -986,7 +997,10 @@ class TestSubmitWeekly:
             })
         }
 
+<<<<<<< Updated upstream
         # Mock user config
+=======
+>>>>>>> Stashed changes
         mock_user = {
             'userId': 'user-123',
             'name': 'Test User',
@@ -994,7 +1008,10 @@ class TestSubmitWeekly:
             'personalEmail': 'test@example.com',
             'rate': 28.00,
             'template': 'morning-light',
+<<<<<<< Updated upstream
             'signatureFont': 'Dancing Script',
+=======
+>>>>>>> Stashed changes
             'paymentTerms': 'receipt',
             'taxEnabled': False,
             'invoiceNumberConfig': {
@@ -1016,6 +1033,7 @@ class TestSubmitWeekly:
 
         mock_pdf_bytes = b'%PDF-1.4\nMock PDF content'
 
+<<<<<<< Updated upstream
         # Mock metadata update failure
         metadata_error = ClientError(
             {
@@ -1026,6 +1044,111 @@ class TestSubmitWeekly:
             },
             'PutItem'
         )
+=======
+        with patch.dict(os.environ, {
+            'USERS_TABLE': 'users-table',
+            'INVOICES_TABLE': 'invoices-table',
+            'SST_Resource_InvoiStorage_name': 'test-bucket'
+        }):
+            with patch('functions.submit_weekly.get_user', return_value=mock_user):
+                with patch('functions.submit_weekly.generate_weekly_invoice', return_value=mock_pdf_bytes):
+                    with patch('functions.submit_weekly.save_pdf_to_s3') as mock_save_s3:
+                        with patch('functions.submit_weekly.put_invoice') as mock_put_invoice:
+                            with patch('functions.submit_weekly.boto3.client') as mock_boto_client:
+                                # Mock DynamoDB client for TransactWriteItems (invoice number increment)
+                                mock_dynamodb_client = MagicMock()
+                                mock_boto_client.return_value = mock_dynamodb_client
+
+                                # Mock S3 client for delete_object
+                                mock_s3_client = MagicMock()
+
+                                # Simulate metadata save failure
+                                mock_put_invoice.side_effect = ClientError(
+                                    {'Error': {'Code': 'ServiceUnavailable', 'Message': 'DynamoDB unavailable'}},
+                                    'PutItem'
+                                )
+
+                                # Patch s3_client used in the handler
+                                with patch('functions.submit_weekly.s3_client', mock_s3_client):
+                                    response = handler(event, {})
+
+                        # Verify the response is an error
+                        assert response['statusCode'] == 500
+                        body = json.loads(response['body'])
+                        assert 'error' in body
+                        assert 'metadata' in body['error'].lower()
+
+                        # Verify S3 upload was called
+                        mock_save_s3.assert_called_once()
+
+                        # Verify put_invoice was called (and failed)
+                        mock_put_invoice.assert_called_once()
+
+                        # Verify the orphaned PDF was deleted from S3
+                        mock_s3_client.delete_object.assert_called_once()
+                        delete_call_kwargs = mock_s3_client.delete_object.call_args[1]
+                        assert delete_call_kwargs['Bucket'] == 'test-bucket'
+                        assert 'INV-20260324.pdf' in delete_call_kwargs['Key']
+
+    def test_metadata_save_failure_handles_s3_delete_failure(self):
+        """When both metadata save and S3 delete fail, should log both errors and return 500"""
+        event = {
+            'requestContext': {
+                'http': {'method': 'POST'},
+                'authorizer': {
+                    'jwt': {
+                        'claims': {'sub': 'user-123'}
+                    }
+                }
+            },
+            'headers': {'Authorization': 'Bearer valid-token'},
+            'body': json.dumps({
+                'hours': {
+                    'Monday': 8,
+                    'Tuesday': 8,
+                    'Wednesday': 8,
+                    'Thursday': 8,
+                    'Friday': 8,
+                    'Saturday': 0,
+                    'Sunday': 0
+                },
+                'week': {
+                    'start': '2026-03-24',
+                    'end': '2026-03-30',
+                    'invNum': 'INV-20260324'
+                },
+                'saveOnly': True
+            })
+        }
+
+        mock_user = {
+            'userId': 'user-123',
+            'name': 'Test User',
+            'address': '123 Main St',
+            'personalEmail': 'test@example.com',
+            'rate': 28.00,
+            'template': 'morning-light',
+            'paymentTerms': 'receipt',
+            'taxEnabled': False,
+            'invoiceNumberConfig': {
+                'prefix': 'INV',
+                'includeYear': False,
+                'separator': '-',
+                'padding': 3,
+                'nextNum': 1
+            },
+            'activeClientId': 'client-1',
+            'clients': [
+                {
+                    'id': 'client-1',
+                    'name': 'Test Client',
+                    'email': 'client@example.com'
+                }
+            ]
+        }
+
+        mock_pdf_bytes = b'%PDF-1.4\nMock PDF content'
+>>>>>>> Stashed changes
 
         with patch.dict(os.environ, {
             'USERS_TABLE': 'users-table',
@@ -1035,6 +1158,7 @@ class TestSubmitWeekly:
             with patch('functions.submit_weekly.get_user', return_value=mock_user):
                 with patch('functions.submit_weekly.generate_weekly_invoice', return_value=mock_pdf_bytes):
                     with patch('functions.submit_weekly.save_pdf_to_s3'):
+<<<<<<< Updated upstream
                         with patch('functions.submit_weekly.boto3.client') as mock_boto_client:
                             with patch('functions.submit_weekly.boto3.resource') as mock_boto_resource:
                                 # Mock DynamoDB client for TransactWriteItems (succeeds)
@@ -1056,3 +1180,35 @@ class TestSubmitWeekly:
         # Should include helpful context about what failed
         assert 'details' in body
         assert 'PDF link' in body['details'] or 'pdfKey' in body.get('details', '')
+=======
+                        with patch('functions.submit_weekly.put_invoice') as mock_put_invoice:
+                            with patch('functions.submit_weekly.boto3.client') as mock_boto_client:
+                                # Mock DynamoDB client for TransactWriteItems
+                                mock_dynamodb_client = MagicMock()
+                                mock_boto_client.return_value = mock_dynamodb_client
+
+                                # Mock S3 client that fails on delete
+                                mock_s3_client = MagicMock()
+                                mock_s3_client.delete_object.side_effect = ClientError(
+                                    {'Error': {'Code': 'AccessDenied', 'Message': 'Access denied'}},
+                                    'DeleteObject'
+                                )
+
+                                # Simulate metadata save failure
+                                mock_put_invoice.side_effect = ClientError(
+                                    {'Error': {'Code': 'ServiceUnavailable', 'Message': 'DynamoDB unavailable'}},
+                                    'PutItem'
+                                )
+
+                                with patch('functions.submit_weekly.s3_client', mock_s3_client):
+                                    response = handler(event, {})
+
+                        # Should still return 500 even if S3 delete fails
+                        assert response['statusCode'] == 500
+                        body = json.loads(response['body'])
+                        assert 'error' in body
+                        assert 'metadata' in body['error'].lower()
+
+                        # Verify S3 delete was attempted (and failed)
+                        mock_s3_client.delete_object.assert_called_once()
+>>>>>>> Stashed changes


### PR DESCRIPTION
## Work in Progress

Closes #85

PDF uploaded to S3 even when metadata save fails

<!-- sharkrite-source-issue:19 -->## From PR #78 Assessment

**Severity:** HIGH
**Category:** CodeQuality

## Issue
Prior assessment classified this identical concern (orphaned S3 objects when metadata update fails) as ACTIONABLE_LATER. The PDF is already saved and usable; the code explicitly comments this as "not a critical failure."

## Context
This is the same orphaned state concern already tracked. The silent failure pattern remains unchanged.

## Defer Reason
Architectural refactor needed - requires restructuring the transaction to include pdfKey or implementing cleanup logic

---
_Created by Sharkrite assessment on 2026-04-04T05:09:14Z_
_Parent PR: #78_

---
_Draft PR created automatically by rite for tracking purposes._

<!-- sharkrite-changes-summary -->
## Changes

**3** files, **7** commits (+0 added, ~3 modified, -0 deleted)
- `M` backend/functions/submit_monthly.py
- `M` backend/functions/submit_weekly.py
- `M` backend/tests/test_submit_weekly.py

### Commits
- 9cded6a wip: auto-commit relevant changes for issue #85 (2026-04-17)
- 6eeb3fe Merge remote-tracking branch 'origin/main' into feat/pdf-uploaded-to-s3-even-when-metadata-save-fails
- ee6cff8 wip: auto-commit relevant changes for issue #85 (2026-04-17)
- 53ac9fb Merge remote-tracking branch 'origin/main' into feat/pdf-uploaded-to-s3-even-when-metadata-save-fails
- f9c4a3c wip: auto-commit relevant changes for issue #85 (2026-04-17)
- 1a0535d Merge remote-tracking branch 'origin/main' into feat/pdf-uploaded-to-s3-even-when-metadata-save-fails
- 26bb318 chore: initialize work on #85 PDF uploaded to S3 even when metadata save fails
<!-- /sharkrite-changes-summary -->



---

## Follow-up Issues
Created: #159 
**From assessment on 2026-04-17T23:52:26Z:**
- Created: #154 
- Updated: none